### PR TITLE
Add Cmd/Ctrl+Enter keyboard shortcut to submit entries

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,13 @@ function App() {
     return date.toLocaleTimeString('ja-JP')
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault()
+      handleAddEntry()
+    }
+  }
+
   return (
     <div className="app">
       <header>
@@ -87,6 +94,7 @@ function App() {
           <textarea
             value={currentEntry}
             onChange={(e) => setCurrentEntry(e.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder="今やっていることを記録..."
             rows={3}
           />


### PR DESCRIPTION
## Summary
- Cmd/Ctrl+Enter キーボードショートカットを実装し、エントリの送信を素早く行えるようにした
- `handleKeyDown` 関数を追加し、テキストエリアでのキーボードイベントを処理
- Mac では Cmd+Enter、Windows/Linux では Ctrl+Enter でエントリを追加できるようになった

## Test plan
- [ ] アプリケーションを起動する
- [ ] テキストエリアに文字を入力する
- [ ] Cmd+Enter（Mac）または Ctrl+Enter（Windows/Linux）を押す
- [ ] エントリが正常に追加されることを確認する
- [ ] 追加ボタンのクリックも引き続き機能することを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)