### PR TITLE
日付ナビゲーション機能とタイムラインUIの実装 (issue #6)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -125,21 +125,104 @@ textarea::placeholder {
 
 .timeline h2 {
   font-size: 1.1rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
 }
 
-.timeline ul {
-  list-style: none;
-  padding: 0;
+.timeline-container {
+  position: relative;
 }
 
-.timeline li {
-  padding: 0.75rem;
-  margin-bottom: 0.5rem;
-  background-color: #fafafa;
-  border-radius: 6px;
-  border-left: 2px solid #ccc;
+.timeline-item {
+  display: grid;
+  grid-template-columns: 60px 40px 1fr;
+  gap: 0;
+  margin-bottom: 1.5rem;
+  position: relative;
+}
+
+.timeline-date {
+  text-align: right;
+  padding-right: 1rem;
+  padding-top: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.date-day {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #333;
+  line-height: 1.2;
+}
+
+.date-month {
+  font-size: 0.75rem;
+  color: #888;
+  text-transform: uppercase;
+  margin-bottom: 0.25rem;
+}
+
+.timeline-date .entry-time {
+  font-size: 0.7rem;
+  color: #aaa;
+  margin-top: 0.25rem;
+}
+
+.timeline-line {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  padding-top: 0.5rem;
+}
+
+.timeline-line::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: -1.5rem;
+  width: 2px;
+  background-color: #e0e0e0;
+  transform: translateX(-50%);
+}
+
+.timeline-item:last-child .timeline-line::before {
+  display: none;
+}
+
+.timeline-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: #4CAF50;
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 2px #e0e0e0;
+  position: relative;
+  z-index: 1;
+}
+
+.timeline-content {
+  padding-left: 1rem;
+}
+
+.entry-card {
+  background-color: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  transition: box-shadow 0.15s;
+}
+
+.entry-card:hover {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.entry-text {
   font-size: 0.9rem;
+  color: #555;
+  line-height: 1.5;
 }
 
 .empty {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,17 +182,43 @@ function App() {
         </div>
 
         <div className="timeline">
-          <h2>{formatDateWithWeekday(selectedDate)}の分報</h2>
           {entries.length === 0 ? (
             <p className="empty">この日の記録がありません</p>
           ) : (
-            <ul>
-              {entries.map((entry) => (
-                <li key={entry.id}>
-                  [{formatTimestamp(entry.timestamp)}] {entry.content}
-                </li>
-              ))}
-            </ul>
+            <div className="timeline-container">
+              {entries.map((entry, index) => {
+                const entryDate = new Date(entry.timestamp)
+                const day = entryDate.getDate()
+                const month = entryDate.toLocaleDateString('ja-JP', { month: 'short' })
+
+                // 前のエントリーと日付を比較
+                const prevEntry = index > 0 ? entries[index - 1] : null
+                const prevDate = prevEntry ? new Date(prevEntry.timestamp).getDate() : null
+                const showDate = prevDate !== day
+
+                return (
+                  <div key={entry.id} className="timeline-item">
+                    <div className="timeline-date">
+                      {showDate ? (
+                        <>
+                          <div className="date-day">{day}</div>
+                          <div className="date-month">{month}</div>
+                        </>
+                      ) : null}
+                      <div className="entry-time">{formatTimestamp(entry.timestamp)}</div>
+                    </div>
+                    <div className="timeline-line">
+                      <div className="timeline-dot"></div>
+                    </div>
+                    <div className="timeline-content">
+                      <div className="entry-card">
+                        <div className="entry-text">{entry.content}</div>
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
           )}
         </div>
       </main>


### PR DESCRIPTION
## 概要
issue #6の日付ナビゲーション機能と、洗練されたタイムラインUIを実装しました。

## 実装内容

### 1. 日付ナビゲーション機能
- 左右の矢印ボタンで前日/翌日に移動
- 「今日」ボタンで今日に戻る
- キーボードショートカット対応
  - ← / → : 前日/翌日へ移動
  - T : 今日へ移動
- 日本語の日付フォーマット表示（曜日付き）
- 選択した日付のエントリーのみをフィルタリング表示

### 2. UIデザインの洗練
- モノトーンカラースキームに統一（グレー基調）
- 全体的に文字サイズを小さく調整
- ボタンを小さく丸みを持たせてミニマルに
- textareaを自動リサイズ対応（リサイズハンドル非表示）
- 送信ボタンを右下に固定配置
- ナビゲーションボタンをボーダーレスに
- input-sectionをカード風デザインに変更

### 3. タイムラインレイアウト
- 左側に日付（日・月）と時刻を表示
- 中央に縦線とドットでタイムライン表現
- 右側にエントリーカードを配置
- 同じ日付の連続表示を避け、日付変更時のみ表示
- グリッドレイアウトで3カラム構成
- カードにホバーエフェクト追加

## スクリーンショット
（必要に応じて追加してください）

## テスト方法
1. アプリを起動
2. 左右の矢印ボタンで日付を移動
3. エントリーを追加してタイムライン表示を確認
4. キーボードショートカット（← → T）を試す

## 関連issue
Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)