### PR TITLE
Fix issue #9: Correct date display timezone handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,14 @@ async function getDb() {
   return db
 }
 
+// ローカルタイムゾーンを考慮した日付文字列を生成（YYYY-MM-DD形式）
+function formatDateToLocalYYYYMMDD(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 function App() {
   const [entries, setEntries] = useState<Entry[]>([])
   const [currentEntry, setCurrentEntry] = useState('')
@@ -43,10 +51,10 @@ function App() {
   const loadEntries = async () => {
     try {
       const database = await getDb()
-      // 選択された日付のエントリーのみを取得（JSTタイムゾーンを考慮）
-      const dateStr = selectedDate.toISOString().split('T')[0]
+      // 選択された日付のエントリーのみを取得（ローカルタイムゾーンを考慮）
+      const dateStr = formatDateToLocalYYYYMMDD(selectedDate)
       const loadedEntries = await database.select<Entry[]>(
-        'SELECT id, content, timestamp FROM entries WHERE DATE(timestamp) = DATE(?) ORDER BY timestamp DESC',
+        'SELECT id, content, timestamp FROM entries WHERE DATE(timestamp, \'localtime\') = DATE(?) ORDER BY timestamp DESC',
         [dateStr]
       )
       setEntries(loadedEntries)


### PR DESCRIPTION
## Summary
- 13日の記録が12日に表示されるタイムゾーンのずれを修正
- `formatDateToLocalYYYYMMDD`関数を追加して、ローカルタイムゾーン（JST）を考慮した日付文字列を生成
- SQLクエリで`DATE(timestamp, 'localtime')`を使用し、UTCタイムスタンプをローカル時刻に変換してから日付比較を実行

## Test plan
- [ ] アプリケーションをビルドして起動する
- [ ] 新しい記録を追加し、選択した日付に正しく表示されることを確認
- [ ] 日付ナビゲーションで前日・翌日に移動し、記録が正しくフィルタリングされることを確認
- [ ] 深夜帯（日付をまたぐ時間帯）での動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)