### PR TITLE
Fix issue #14: Display line breaks in entry content

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -251,6 +251,7 @@ textarea::placeholder {
   font-size: 0.9rem;
   color: #555;
   line-height: 1.5;
+  white-space: pre-wrap;
 }
 
 .empty {


### PR DESCRIPTION
## Summary

記録の内容に含まれる改行が正しく表示されるようにCSSを修正したのだ。

## Changes

- `src/App.css`の`.entry-text`クラスに`white-space: pre-wrap;`を追加
  - これにより、改行文字が保持されて表示される
  - 長いテキストも自動的に折り返される
  - 連続するスペースも保持される

## Test plan

- [ ] アプリケーションを起動
- [ ] 改行を含むテキストを入力して記録を作成
- [ ] 記録が改行付きで正しく表示されることを確認
- [ ] 長いテキストが適切に折り返されることを確認
- [ ] 削除ボタンが正しく表示されることを確認（rebase後）

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)