### PR TITLE
Implement issue #18: Add thread-style reply feature

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -308,6 +308,28 @@ textarea::placeholder {
   color: #333;
 }
 
+.show-replies-button {
+  padding: 0.2rem 0.4rem;
+  font-size: 0.7rem;
+  background-color: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  color: #999;
+  transition: all 0.15s;
+}
+
+.show-replies-button:hover {
+  background-color: #f9f9f9;
+  color: #666;
+}
+
+.reply-count {
+  font-size: 0.65rem;
+  color: #bbb;
+  font-weight: 400;
+}
+
 /* Reply Input Section */
 .reply-input-section {
   margin-top: 0.75rem;
@@ -412,6 +434,38 @@ textarea::placeholder {
 
 .reply-text {
   font-size: 0.9rem;
+  color: #555;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+/* Entry Replies List */
+.entry-replies-list {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #f0f0f0;
+}
+
+.entry-reply-item {
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.5rem;
+  background-color: #f9f9f9;
+  border-radius: 6px;
+  border: 1px solid #e5e5e5;
+}
+
+.entry-reply-item:last-child {
+  margin-bottom: 0;
+}
+
+.entry-reply-time {
+  font-size: 0.7rem;
+  color: #aaa;
+  margin-bottom: 0.25rem;
+}
+
+.entry-reply-text {
+  font-size: 0.85rem;
   color: #555;
   line-height: 1.5;
   white-space: pre-wrap;


### PR DESCRIPTION
## 概要
Issue #18で要求されていたスレッド形式の返信機能を実装しました。エントリーに対して返信を追加し、タイムライン上で時系列に表示したり、エントリカード内で確認したりできるようになりました。

## 実装内容

### 1. 基本的な返信機能
- エントリーに対して返信を追加できる機能
- 返信の削除機能（確認ダイアログ付き）
- SQLiteデータベースに`replies`テーブルを追加（CASCADE DELETE対応）
- パフォーマンス最適化のためのインデックス追加

### 2. タイムライン表示
- エントリーと返信を統合した時系列タイムラインビュー
- 全ての記録と返信を時系列順（降順）で表示
- 返信カードには親エントリーへの参照を表示
- 参照をクリックすると親エントリーにスムーズスクロール＋ハイライト表示
- 視覚的な区別（返信のドットは灰色）

### 3. エントリカード内での返信表示
- エントリカードに返信数を控えめに表示（返信がある場合のみ）
- 「▶ 返信を表示」ボタンで返信一覧を展開/折りたたみ
- カード内で返信を時系列順（昇順）に表示
- 二つの視点：タイムライン全体での閲覧 or エントリ単位での閲覧

### 4. UIの改善
- 返信数の表示を極めて控えめに（小さく薄いグレー、0件の場合は非表示）
- 返信カードはグレー系の落ち着いたデザイン
- ホバー時のみ削除ボタンを表示
- Reactレンダリングの問題（0が表示される）を修正（nullish coalescing使用）
- Cmd/Ctrl+Enterで返信を送信

## テスト計画
- [x] エントリーへの返信追加
- [x] 返信の削除（確認ダイアログ）
- [x] タイムラインでの時系列表示
- [x] 親エントリーへのスクロール・ハイライト
- [x] エントリカード内での返信展開/折りたたみ
- [x] 返信数の表示（0件の場合は非表示）
- [x] CASCADE DELETEの動作確認
- [x] 返信追加/削除時の状態同期
- [x] ビルドが成功する

## 変更ファイル
- `src/App.tsx`: ロジックとUI追加（+592行）
- `src/App.css`: スタイル追加（-28行）

## 関連Issue
Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)