### PR TITLE
エントリと返信を編集可能にする (issue #21)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -264,6 +264,98 @@ textarea::placeholder {
   color: #e53e3e;
 }
 
+.edit-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 2.5rem;
+  padding: 0.4rem;
+  background-color: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  color: #999;
+  opacity: 0;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.entry-card:hover .edit-button,
+.reply-card:hover .edit-button {
+  opacity: 1;
+}
+
+.edit-button:hover {
+  background-color: #f0f8ff;
+  color: #2196F3;
+}
+
+/* Edit Input Section */
+.edit-input-section {
+  margin-top: 0;
+  padding: 0;
+  background-color: transparent;
+  border: none;
+}
+
+.edit-textarea {
+  width: 100%;
+  padding: 0.25rem;
+  font-size: 0.9rem;
+  border: 1px solid #e5e5e5;
+  border-radius: 4px;
+  resize: none;
+  font-family: inherit;
+  background-color: #fff;
+  color: #555;
+  min-height: 80px;
+  overflow: hidden;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  transition: border-color 0.15s;
+}
+
+.edit-textarea:focus {
+  outline: none;
+  border-color: #2196F3;
+}
+
+.edit-buttons {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  justify-content: flex-end;
+}
+
+.save-button,
+.cancel-button {
+  padding: 0.3rem 0.7rem;
+  font-size: 0.7rem;
+  border: none;
+  border-radius: 15px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.save-button {
+  background-color: #333;
+  color: #fff;
+}
+
+.save-button:hover {
+  background-color: #000;
+}
+
+.cancel-button {
+  background-color: #e5e5e5;
+  color: #666;
+}
+
+.cancel-button:hover {
+  background-color: #d0d0d0;
+}
+
 .entry-text {
   font-size: 0.9rem;
   color: #555;


### PR DESCRIPTION
## Summary

issue #21「エントリを編集可能にする」の実装です。エントリと返信の両方に編集機能を追加しました。

### 実装内容

- ✅ エントリと返信の両方に編集ボタン（鉛筆アイコン）を追加
- ✅ インライン編集UIを実装（既存のデザインと統一）
- ✅ データベース更新処理（UPDATE文）を実装
- ✅ 編集時のtextarea高さ自動調整機能
- ✅ キーボードショートカット対応（Cmd+Enter: 保存、Esc: キャンセル）
- ✅ バリデーション（空白のみの内容は保存不可）
- ✅ 既存UIとの統一（ボタンの色、配置、スタイル）

### 変更ファイル

- `src/App.tsx`: 編集機能のロジック実装
  - エントリ編集: `startEditEntry()`, `handleUpdateEntry()`, `cancelEditEntry()`
  - 返信編集: `startEditReply()`, `handleUpdateReply()`, `cancelEditReply()`
  - textarea高さ自動調整のuseEffect
- `src/App.css`: 編集UIのスタイル追加

### UI/UX

- エントリカードと返信カードにホバー時に編集・削除ボタンが表示されます
- 編集ボタンをクリックすると、インラインで編集フォームが表示されます
- 編集中のtextareaは元のコンテンツの長さに合わせて高さが自動調整されます
- 保存・キャンセルボタンは既存の送信ボタンと同じスタイル（黒系ボタン）です

## Test plan

- [ ] エントリの編集ボタンが表示され、クリックで編集モードに入ることを確認
- [ ] エントリの内容を編集して保存できることを確認
- [ ] 編集をキャンセルできることを確認
- [ ] 返信の編集ボタンが表示され、同様に編集できることを確認
- [ ] Cmd+Enterで保存、Escでキャンセルが動作することを確認
- [ ] 空白のみの内容は保存できないことを確認
- [ ] textarea高さが自動調整されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)