### PR TITLE
日付を跨いでのタグフィルタリング表示を実装 (issue #33)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -839,3 +839,61 @@ textarea::placeholder {
   text-align: center;
   line-height: 1.2;
 }
+
+/* ページネーション */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.pagination-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.page-number {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #555;
+}
+
+.item-count {
+  font-size: 0.75rem;
+  color: #888;
+}
+
+.pagination .nav-button:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.pagination .nav-button:disabled:hover {
+  background-color: transparent;
+  color: #888;
+}
+
+/* 日付別グループ化表示 */
+.timeline-date-group {
+  margin-bottom: 2rem;
+}
+
+.timeline-date-header {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #555;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  background: linear-gradient(to right, #f8f9fa 0%, #e9ecef 100%);
+  border-left: 4px solid #5cb85c;
+  border-radius: 4px;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { DateNavigation } from '@/components/DateNavigation'
 import { DeleteConfirmDialogs } from '@/components/DeleteConfirmDialogs'
 import { InputSection } from '@/components/InputSection'
 import { Timeline } from '@/components/Timeline'
+import { Pagination } from '@/components/Pagination'
 import { PinnedSidebar } from '@/components/PinnedSidebar'
 import { useDatabase } from '@/hooks/useDatabase'
 import { useDateNavigation } from '@/hooks/useDateNavigation'
@@ -50,7 +51,16 @@ function App() {
   } = useTags({ database, loadEntries: async () => {} })
 
   // タイムライン
-  const { timelineItems: filteredTimelineItems, setTimelineItems: setFilteredTimelineItems, handleScrollToEntry: scrollToEntry } = useTimeline({
+  const {
+    timelineItems: filteredTimelineItems,
+    setTimelineItems: setFilteredTimelineItems,
+    handleScrollToEntry: scrollToEntry,
+    currentPage,
+    setCurrentPage,
+    totalPages,
+    totalItems,
+    itemsPerPage,
+  } = useTimeline({
     database,
     selectedDate,
     selectedTags,
@@ -186,8 +196,19 @@ function App() {
           }}
         />
 
+        {selectedTags.length > 0 && (
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            totalItems={totalItems}
+            itemsPerPage={itemsPerPage}
+            onPageChange={setCurrentPage}
+          />
+        )}
+
         <Timeline
           timelineItems={filteredTimelineItems}
+          isTagFiltering={selectedTags.length > 0}
           editingEntryId={editingEntryId}
           editContent={editContent}
           editManualTags={editManualTags}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,63 @@
+interface PaginationProps {
+  currentPage: number
+  totalPages: number
+  totalItems: number
+  itemsPerPage: number
+  onPageChange: (page: number) => void
+}
+
+export function Pagination({
+  currentPage,
+  totalPages,
+  totalItems,
+  itemsPerPage,
+  onPageChange,
+}: PaginationProps) {
+  if (totalPages <= 1) {
+    return null // ページが1つしかない場合は何も表示しない
+  }
+
+  const handlePrevious = () => {
+    if (currentPage > 1) {
+      onPageChange(currentPage - 1)
+    }
+  }
+
+  const handleNext = () => {
+    if (currentPage < totalPages) {
+      onPageChange(currentPage + 1)
+    }
+  }
+
+  const startItem = (currentPage - 1) * itemsPerPage + 1
+  const endItem = Math.min(currentPage * itemsPerPage, totalItems)
+
+  return (
+    <div className="pagination">
+      <button
+        onClick={handlePrevious}
+        disabled={currentPage === 1}
+        className="nav-button"
+        aria-label="前のページ"
+      >
+        ◀
+      </button>
+      <div className="pagination-info">
+        <span className="page-number">
+          {currentPage} / {totalPages}
+        </span>
+        <span className="item-count">
+          ({startItem}-{endItem} / {totalItems}件)
+        </span>
+      </div>
+      <button
+        onClick={handleNext}
+        disabled={currentPage === totalPages}
+        className="nav-button"
+        aria-label="次のページ"
+      >
+        ▶
+      </button>
+    </div>
+  )
+}

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,8 +1,10 @@
 import { TimelineItem, Tag } from '@/types'
 import { TimelineItemComponent } from './TimelineItemComponent'
+import { groupTimelineItemsByDate } from '@/utils/timelineUtils'
 
 interface TimelineProps {
   timelineItems: TimelineItem[]
+  isTagFiltering: boolean
   editingEntryId: number | null
   editContent: string
   editManualTags: string[]
@@ -42,6 +44,7 @@ interface TimelineProps {
 
 export function Timeline({
   timelineItems,
+  isTagFiltering,
   editingEntryId,
   editContent,
   editManualTags,
@@ -78,11 +81,70 @@ export function Timeline({
   onScrollToEntry,
   onTogglePin,
 }: TimelineProps) {
+  // タグフィルタリング時は日付別にグループ化
+  const groupedItems = isTagFiltering ? groupTimelineItemsByDate(timelineItems) : null
+
   return (
     <div className="timeline">
       {timelineItems.length === 0 ? (
-        <p className="empty">この日の記録がありません</p>
+        <p className="empty">
+          {isTagFiltering ? 'タグに一致する記録がありません' : 'この日の記録がありません'}
+        </p>
+      ) : isTagFiltering && groupedItems ? (
+        // タグフィルタリング時: 日付別グループ化表示
+        <div className="timeline-container">
+          {groupedItems.map((group) => (
+            <div key={group.date} className="timeline-date-group">
+              <div className="timeline-date-header">
+                {group.displayDate}
+              </div>
+              {group.items.map((item, index) => (
+                <TimelineItemComponent
+                  key={`${item.type}-${item.id}`}
+                  item={item}
+                  previousItem={index > 0 ? group.items[index - 1] : null}
+                  editingEntryId={editingEntryId}
+                  editContent={editContent}
+                  editManualTags={editManualTags}
+                  editingReplyId={editingReplyId}
+                  editReplyContent={editReplyContent}
+                  editReplyManualTags={editReplyManualTags}
+                  availableTags={availableTags}
+                  selectedTags={selectedTags}
+                  replyingToId={replyingToId}
+                  replyContent={replyContent}
+                  replyManualTags={replyManualTags}
+                  expandedEntryReplies={expandedEntryReplies}
+                  onEditEntry={onEditEntry}
+                  onCancelEditEntry={onCancelEditEntry}
+                  onUpdateEntry={onUpdateEntry}
+                  onDeleteEntry={onDeleteEntry}
+                  onEditContentChange={onEditContentChange}
+                  onEditTagAdd={onEditTagAdd}
+                  onEditTagRemove={onEditTagRemove}
+                  onEditReply={onEditReply}
+                  onCancelEditReply={onCancelEditReply}
+                  onUpdateReply={onUpdateReply}
+                  onDeleteReply={onDeleteReply}
+                  onEditReplyContentChange={onEditReplyContentChange}
+                  onEditReplyTagAdd={onEditReplyTagAdd}
+                  onEditReplyTagRemove={onEditReplyTagRemove}
+                  onTagClick={onTagClick}
+                  onReplyToggle={onReplyToggle}
+                  onReplyContentChange={onReplyContentChange}
+                  onReplyTagAdd={onReplyTagAdd}
+                  onReplyTagRemove={onReplyTagRemove}
+                  onAddReply={onAddReply}
+                  onToggleReplies={onToggleReplies}
+                  onScrollToEntry={onScrollToEntry}
+                  onTogglePin={onTogglePin}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
       ) : (
+        // 通常表示: 日付別グループ化なし
         <div className="timeline-container">
           {timelineItems.map((item, index) => (
             <TimelineItemComponent

--- a/src/utils/timelineUtils.ts
+++ b/src/utils/timelineUtils.ts
@@ -1,0 +1,69 @@
+import { TimelineItem } from '@/types'
+import { formatDateToLocalYYYYMMDD } from './dateUtils'
+
+export interface GroupedTimelineItems {
+  date: string
+  displayDate: string
+  items: TimelineItem[]
+}
+
+/**
+ * タイムラインアイテムを日付別にグループ化する
+ * @param items タイムラインアイテムの配列
+ * @returns 日付別にグループ化されたアイテム
+ */
+export function groupTimelineItemsByDate(items: TimelineItem[]): GroupedTimelineItems[] {
+  const grouped = new Map<string, TimelineItem[]>()
+
+  // 各アイテムを日付ごとに分類
+  items.forEach((item) => {
+    const date = new Date(item.timestamp)
+    const dateKey = formatDateToLocalYYYYMMDD(date)
+
+    if (!grouped.has(dateKey)) {
+      grouped.set(dateKey, [])
+    }
+    grouped.get(dateKey)!.push(item)
+  })
+
+  // Map を配列に変換し、日付の降順でソート
+  const result: GroupedTimelineItems[] = Array.from(grouped.entries())
+    .map(([date, items]) => {
+      // 各グループ内でピン留め優先、その後時系列順にソート
+      const sortedItems = [...items].sort((a, b) => {
+        const aPinned = a.type === 'entry' && a.pinned ? 1 : 0
+        const bPinned = b.type === 'entry' && b.pinned ? 1 : 0
+
+        if (aPinned !== bPinned) {
+          return bPinned - aPinned
+        }
+
+        return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+      })
+
+      return {
+        date,
+        displayDate: formatDisplayDate(date),
+        items: sortedItems,
+      }
+    })
+    .sort((a, b) => b.date.localeCompare(a.date)) // 日付の降順
+
+  return result
+}
+
+/**
+ * 日付文字列を表示用にフォーマット
+ * @param dateStr YYYY-MM-DD形式の日付文字列
+ * @returns 表示用の日付文字列（例: 2024年1月15日（月））
+ */
+function formatDisplayDate(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00')
+  const year = date.getFullYear()
+  const month = date.getMonth() + 1
+  const day = date.getDate()
+  const weekdays = ['日', '月', '火', '水', '木', '金', '土']
+  const weekday = weekdays[date.getDay()]
+
+  return `${year}年${month}月${day}日（${weekday}）`
+}


### PR DESCRIPTION
## 概要

issue #33 で要望されていた、タグフィルタリング時に日付を跨いでエントリーを表示する機能を実装しました。

## 実装内容

### 主要な機能

- ✅ **日付を跨いだタグフィルタリング**: タグが選択されている場合、すべての日付からエントリーを取得
- ✅ **日付別グループ化表示**: 取得したエントリーを日付ごとにグループ化し、見やすい日付ヘッダーを表示
- ✅ **ページネーション**: 大量のデータに対応するため、1ページ20件のページネーション機能を実装

### 変更ファイル

#### 新規作成
- `src/components/Pagination.tsx` - ページネーションUIコンポーネント
- `src/utils/timelineUtils.ts` - 日付別グループ化ロジック

#### 修正
- `src/hooks/useTimeline.ts` - タグフィルタリング時の日付条件除外とページネーション対応
- `src/components/Timeline.tsx` - 日付別グループ化表示に対応
- `src/App.tsx` - ページネーション統合
- `src/App.css` - ページネーションと日付ヘッダーのスタイル追加

## 動作

### タグフィルタリング無効時（従来通り）
- 選択された日付のエントリーのみを表示
- ページネーションなし

### タグフィルタリング有効時（新機能）
- すべての日付からタグに一致するエントリーを取得
- 日付別にグループ化して表示
- 20件を超える場合はページネーション表示

## テスト

- ✅ ビルド成功（TypeScriptエラーなし）
- ✅ 既存機能との互換性確認

## スクリーンショット

（実際の動作確認後に追加予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)