### PR TITLE
起動時にピン留めサイドバーを閉じた状態にする (issue #35)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ import { useReplies } from '@/hooks/useReplies'
 
 function App() {
   const [settingsOpen, setSettingsOpen] = useState(false)
-  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [sidebarOpen, setSidebarOpen] = useState(false)
 
   // データベース
   const database = useDatabase()


### PR DESCRIPTION
## 概要
issue #35の対応。アプリケーション起動時にピン留めサイドバーが自動的に開かないようにした。

## 変更内容
- `src/App.tsx:21` - `sidebarOpen`の初期値を`true`から`false`に変更

## 動作
- アプリケーション起動時、サイドバーは閉じた状態になる
- ユーザーは必要に応じてFABボタンをクリックしてサイドバーを開ける
- ピン留め機能自体は影響を受けない（既存の動作を維持）

## テスト計画
- [x] アプリケーションを起動し、サイドバーが閉じた状態であることを確認
- [x] FABボタンをクリックしてサイドバーが開くことを確認
- [x] ピン留め機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)