### PR TITLE
全文検索機能とフィルタUIを実装 (issue #43)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-label": "^2.1.8",
@@ -1865,6 +1866,36 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/FScoward/funhou#readme",
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.15",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,13 @@
 import { useState, useMemo, useEffect } from 'react'
 import './App.css'
 import { SettingsDialog } from '@/components/SettingsDialog'
-import { TagFilter } from '@/components/TagFilter'
 import { DateNavigation } from '@/components/DateNavigation'
 import { DeleteConfirmDialogs } from '@/components/DeleteConfirmDialogs'
 import { InputSection } from '@/components/InputSection'
 import { Timeline } from '@/components/Timeline'
 import { Pagination } from '@/components/Pagination'
 import { PinnedSidebar } from '@/components/PinnedSidebar'
+import { FilterBar } from '@/components/FilterBar'
 import { useDatabase } from '@/hooks/useDatabase'
 import { useDateNavigation } from '@/hooks/useDateNavigation'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
@@ -20,6 +20,7 @@ import { getSettings } from '@/lib/settings'
 function App() {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [searchText, setSearchText] = useState('')
 
   // データベース
   const database = useDatabase()
@@ -99,6 +100,7 @@ function App() {
     selectedDate,
     selectedTags,
     filterMode,
+    searchText,
   })
 
   // エントリー
@@ -188,30 +190,30 @@ function App() {
           onSettingsClick={() => setSettingsOpen(true)}
         />
 
-        <div className="tag-filter-section">
-          <TagFilter
-            availableTags={availableTags}
-            selectedTags={selectedTags}
-            filterMode={filterMode}
-            onTagSelect={(tag) => {
-              if (selectedTags.includes(tag)) {
-                setSelectedTags(selectedTags.filter(t => t !== tag))
-              } else {
-                setSelectedTags([...selectedTags, tag])
-              }
-            }}
-            onTagRemove={(tag) => {
+        <FilterBar
+          availableTags={availableTags}
+          selectedTags={selectedTags}
+          filterMode={filterMode}
+          onTagSelect={(tag) => {
+            if (selectedTags.includes(tag)) {
               setSelectedTags(selectedTags.filter(t => t !== tag))
-            }}
-            onFilterModeChange={(mode) => {
-              setFilterMode(mode)
-            }}
-            onClearAll={() => {
-              setSelectedTags([])
-            }}
-            onTagDelete={openDeleteTagDialog}
-          />
-        </div>
+            } else {
+              setSelectedTags([...selectedTags, tag])
+            }
+          }}
+          onTagRemove={(tag) => {
+            setSelectedTags(selectedTags.filter(t => t !== tag))
+          }}
+          onFilterModeChange={(mode) => {
+            setFilterMode(mode)
+          }}
+          onTagsClearAll={() => {
+            setSelectedTags([])
+          }}
+          onTagDelete={openDeleteTagDialog}
+          onSearch={setSearchText}
+          searchText={searchText}
+        />
 
         <InputSection
           currentEntry={currentEntry}
@@ -230,7 +232,7 @@ function App() {
           }}
         />
 
-        {selectedTags.length > 0 && (
+        {(selectedTags.length > 0 || searchText.trim().length > 0) && (
           <Pagination
             currentPage={currentPage}
             totalPages={totalPages}
@@ -242,7 +244,7 @@ function App() {
 
         <Timeline
           timelineItems={filteredTimelineItems}
-          isTagFiltering={selectedTags.length > 0}
+          isTagFiltering={selectedTags.length > 0 || searchText.trim().length > 0}
           editingEntryId={editingEntryId}
           editContent={editContent}
           editManualTags={editManualTags}

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react'
+import { Tag as TagIcon, Search, Filter } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import * as Collapsible from '@radix-ui/react-collapsible'
+import { TagFilter } from './TagFilter'
+import { SearchInput } from './SearchInput'
+import { Tag } from '@/types'
+
+interface FilterBarProps {
+  // タグフィルタ関連
+  availableTags: Tag[]
+  selectedTags: string[]
+  filterMode: 'AND' | 'OR'
+  onTagSelect: (tag: string) => void
+  onTagRemove: (tag: string) => void
+  onFilterModeChange: (mode: 'AND' | 'OR') => void
+  onTagsClearAll: () => void
+  onTagDelete: (tag: string) => void
+  // 検索関連
+  onSearch: (searchText: string) => void
+  searchText: string
+}
+
+type FilterType = 'tag' | 'search' | null
+
+export function FilterBar({
+  availableTags,
+  selectedTags,
+  filterMode,
+  onTagSelect,
+  onTagRemove,
+  onFilterModeChange,
+  onTagsClearAll,
+  onTagDelete,
+  onSearch,
+  searchText,
+}: FilterBarProps) {
+  const [expandedFilter, setExpandedFilter] = useState<FilterType>(null)
+
+  const toggleFilter = (filterType: FilterType) => {
+    setExpandedFilter(expandedFilter === filterType ? null : filterType)
+  }
+
+  const hasActiveSearch = searchText.trim().length > 0
+
+  return (
+    <div className="border-b pb-3 mb-4">
+      {/* フィルタアイコンバー */}
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-muted-foreground mr-2">フィルタ:</span>
+
+        {/* タグフィルタアイコン */}
+        <Button
+          variant={expandedFilter === 'tag' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => toggleFilter('tag')}
+          className="relative"
+        >
+          <TagIcon className="h-4 w-4 mr-1" />
+          タグ
+          {selectedTags.length > 0 && (
+            <Badge variant="secondary" className="ml-2 h-5 min-w-5 px-1">
+              {selectedTags.length}
+            </Badge>
+          )}
+        </Button>
+
+        {/* 検索フィルタアイコン */}
+        <Button
+          variant={expandedFilter === 'search' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => toggleFilter('search')}
+          className="relative"
+        >
+          <Search className="h-4 w-4 mr-1" />
+          検索
+          {hasActiveSearch && (
+            <Badge variant="secondary" className="ml-2 h-5 min-w-5 px-1">
+              ●
+            </Badge>
+          )}
+        </Button>
+
+        {/* アクティブフィルタの概要表示 */}
+        {(selectedTags.length > 0 || hasActiveSearch) && (
+          <div className="ml-auto flex items-center gap-2 text-sm text-muted-foreground">
+            <Filter className="h-4 w-4" />
+            <span>フィルタリング中</span>
+          </div>
+        )}
+      </div>
+
+      {/* タグフィルタ展開エリア */}
+      <Collapsible.Root open={expandedFilter === 'tag'}>
+        <Collapsible.Content className="mt-3">
+          <div className="p-4 border rounded-lg bg-muted/30">
+            <TagFilter
+              availableTags={availableTags}
+              selectedTags={selectedTags}
+              filterMode={filterMode}
+              onTagSelect={onTagSelect}
+              onTagRemove={onTagRemove}
+              onFilterModeChange={onFilterModeChange}
+              onClearAll={onTagsClearAll}
+              onTagDelete={onTagDelete}
+            />
+          </div>
+        </Collapsible.Content>
+      </Collapsible.Root>
+
+      {/* 検索フィルタ展開エリア */}
+      <Collapsible.Root open={expandedFilter === 'search'}>
+        <Collapsible.Content className="mt-3">
+          <div className="p-4 border rounded-lg bg-muted/30">
+            <SearchInput onSearch={onSearch} value={searchText} />
+          </div>
+        </Collapsible.Content>
+      </Collapsible.Root>
+    </div>
+  )
+}

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,0 +1,70 @@
+import { useState, useEffect } from 'react'
+import { Search, X } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+interface SearchInputProps {
+  onSearch: (searchText: string) => void
+  value?: string
+  className?: string
+}
+
+export function SearchInput({ onSearch, value = '', className = '' }: SearchInputProps) {
+  const [searchText, setSearchText] = useState(value)
+
+  // 親の値が変わったら同期
+  useEffect(() => {
+    setSearchText(value)
+  }, [value])
+
+  const handleSearch = () => {
+    onSearch(searchText.trim())
+  }
+
+  const handleClear = () => {
+    setSearchText('')
+    onSearch('')
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSearch()
+    }
+  }
+
+  return (
+    <div className={`w-full ${className}`}>
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground pointer-events-none" />
+        <Input
+          type="text"
+          placeholder="エントリーと返信を検索..."
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className="pl-10 pr-20 h-11 text-base"
+        />
+        <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
+          {searchText && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleClear}
+              className="h-7 w-7 p-0 hover:bg-muted"
+              title="クリア"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+          <Button
+            onClick={handleSearch}
+            size="sm"
+            className="h-8 px-3"
+          >
+            検索
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }


### PR DESCRIPTION
## 概要
issue #43 の全文検索機能を実装し、さらにフィルタUIを大幅に改善しました。

## 実装した機能

### 🔍 全文検索機能
- **検索対象**: エントリーと返信の両方を検索
- **検索方式**: SQL LIKE による部分一致検索
- **フィルタ併用**: タグフィルタとの併用可能（AND条件）
- **日付範囲**: 全日付を横断して検索
- **ページネーション**: 20件/ページで表示
- **並び順**: ピン留め優先 → 日付降順（新しい順）

### 🎨 フィルタUI改善
- **アイコンバー方式**: タグと検索のアイコンボタンを配置
- **バッジ表示**: 
  - タグフィルタ: 選択中のタグ数を表示
  - 検索: 検索中は●マークを表示
- **展開方式**: アイコンクリックで下に展開してUIを表示
- **状態保持**: フィルタUIを閉じても検索テキストが保持される
- **クリーンなデザイン**: 使用していない時はアイコンバーのみでスッキリ

## 変更ファイル

### 新規作成
- `src/components/FilterBar.tsx` - フィルタバーコンポーネント
- `src/components/SearchInput.tsx` - 検索入力コンポーネント
- `src/components/ui/badge.tsx` - バッジコンポーネント

### 更新
- `src/App.tsx` - FilterBarの統合
- `src/hooks/useTimeline.ts` - 検索ロジックの実装
- `package.json` - @radix-ui/react-collapsible の追加

## テスト確認項目
- [x] エントリーの全文検索が動作する
- [x] 返信の全文検索が動作する
- [x] タグフィルタと検索の併用が動作する
- [x] 検索結果がページネーション表示される
- [x] フィルタUIの展開/折りたたみが動作する
- [x] バッジが正しく表示される
- [x] 検索テキストが保持される
- [x] ビルドエラーがない

## スクリーンショット
フィルタバーとアイコン+バッジ表示:
```
フィルタ: [🏷️ タグ 2] [🔍 検索 ●]  フィルタリング中
```

検索UI展開時:
```
フィルタ: [🏷️ タグ] [🔍 検索*]
┌──────────────────────────────────┐
│ エントリーと返信を検索...    [検索] │
└──────────────────────────────────┘
```

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)