### PR TITLE
fix: remove unused useState import in CustomInput.tsx

### DIFF
--- a/src/components/CustomInput.tsx
+++ b/src/components/CustomInput.tsx
@@ -1,6 +1,6 @@
 import TextareaAutosize from "react-textarea-autosize"
 import { ArrowUp } from "lucide-react"
-import { useState } from "react"
+
 
 import {
   InputGroup,


### PR DESCRIPTION
Fixes build error caused by unused import.