### PR TITLE
feat: タグをカテゴリ分けして表示する機能を実装 (#54)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,6 +83,8 @@ function App() {
     handleTagClick,
     openDeleteTagDialog,
     handleDeleteTag,
+    frequentTags,
+    recentTags,
   } = useTags({ database, loadEntries: async () => { } })
 
   // タイムライン
@@ -214,6 +216,8 @@ function App() {
             setSelectedTags([])
           }}
           onTagDelete={openDeleteTagDialog}
+          frequentTags={frequentTags}
+          recentTags={recentTags}
           onSearch={setSearchText}
           searchText={searchText}
         />
@@ -233,6 +237,8 @@ function App() {
           onTagRemove={(tag) => {
             setManualTags(manualTags.filter(t => t !== tag))
           }}
+          frequentTags={frequentTags}
+          recentTags={recentTags}
         />
 
         {(selectedTags.length > 0 || searchText.trim().length > 0) && (
@@ -260,6 +266,8 @@ function App() {
           replyContent={replyContent}
           replyManualTags={replyManualTags}
           expandedEntryReplies={expandedEntryReplies}
+          frequentTags={frequentTags}
+          recentTags={recentTags}
           onEditEntry={startEditEntry}
           onCancelEditEntry={cancelEditEntry}
           onUpdateEntry={handleUpdateEntry}

--- a/src/components/CustomInput.tsx
+++ b/src/components/CustomInput.tsx
@@ -8,11 +8,7 @@ import {
   InputGroupButton,
 } from "@/components/ui/input-group"
 import { TagSelector } from "@/components/TagSelector"
-
-interface Tag {
-  id: number
-  name: string
-}
+import type { Tag } from "@/types"
 
 interface CustomInputProps {
   value: string
@@ -24,6 +20,8 @@ interface CustomInputProps {
   selectedTags?: string[]
   onTagAdd?: (tag: string) => void
   onTagRemove?: (tag: string) => void
+  frequentTags?: Tag[]
+  recentTags?: Tag[]
 }
 
 export default function CustomInput({
@@ -35,7 +33,9 @@ export default function CustomInput({
   availableTags = [],
   selectedTags = [],
   onTagAdd,
-  onTagRemove
+  onTagRemove,
+  frequentTags = [],
+  recentTags = []
 }: CustomInputProps) {
   const hasContent = value.trim().length > 0
   const showTagSelector = onTagAdd && onTagRemove
@@ -74,6 +74,8 @@ export default function CustomInput({
             selectedTags={selectedTags}
             onTagAdd={onTagAdd}
             onTagRemove={onTagRemove}
+            frequentTags={frequentTags}
+            recentTags={recentTags}
           />
         </div>
       )}

--- a/src/components/EntryCard.tsx
+++ b/src/components/EntryCard.tsx
@@ -23,6 +23,8 @@ interface EntryCardProps {
   replyContent: string
   replyManualTags: string[]
   expandedReplies: boolean
+  frequentTags?: Tag[]
+  recentTags?: Tag[]
   onEdit: (id: number, content: string) => void
   onCancelEdit: () => void
   onUpdateEntry: (id: number) => void
@@ -59,6 +61,8 @@ export function EntryCard({
   replyContent,
   replyManualTags,
   expandedReplies,
+  frequentTags = [],
+  recentTags = [],
   onEdit,
   onCancelEdit,
   onUpdateEntry,
@@ -130,6 +134,8 @@ export function EntryCard({
             selectedTags={editManualTags}
             onTagAdd={onEditTagAdd}
             onTagRemove={onEditTagRemove}
+            frequentTags={frequentTags}
+            recentTags={recentTags}
           />
         </div>
       ) : (
@@ -158,6 +164,8 @@ export function EntryCard({
                 availableTags={availableTags}
                 selectedTags={tags.map(t => t.name)}
                 onTagAdd={onDirectTagAdd}
+                frequentTags={frequentTags}
+                recentTags={recentTags}
               />
             </div>
           )}
@@ -167,6 +175,8 @@ export function EntryCard({
                 availableTags={availableTags}
                 selectedTags={[]}
                 onTagAdd={onDirectTagAdd}
+                frequentTags={frequentTags}
+                recentTags={recentTags}
               />
             </div>
           )}
@@ -215,6 +225,8 @@ export function EntryCard({
             selectedTags={replyManualTags}
             onTagAdd={onReplyTagAdd}
             onTagRemove={onReplyTagRemove}
+            frequentTags={frequentTags}
+            recentTags={recentTags}
           />
         </div>
       )}

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -17,6 +17,8 @@ interface FilterBarProps {
   onFilterModeChange: (mode: 'AND' | 'OR') => void
   onTagsClearAll: () => void
   onTagDelete: (tag: string) => void
+  frequentTags?: Tag[]
+  recentTags?: Tag[]
   // 検索関連
   onSearch: (searchText: string) => void
   searchText: string
@@ -33,6 +35,8 @@ export function FilterBar({
   onFilterModeChange,
   onTagsClearAll,
   onTagDelete,
+  frequentTags,
+  recentTags,
   onSearch,
   searchText,
 }: FilterBarProps) {
@@ -104,6 +108,8 @@ export function FilterBar({
               onFilterModeChange={onFilterModeChange}
               onClearAll={onTagsClearAll}
               onTagDelete={onTagDelete}
+              frequentTags={frequentTags}
+              recentTags={recentTags}
             />
           </div>
         </Collapsible.Content>

--- a/src/components/InputSection.tsx
+++ b/src/components/InputSection.tsx
@@ -10,6 +10,8 @@ interface InputSectionProps {
   selectedTags: string[]
   onTagAdd: (tag: string) => void
   onTagRemove: (tag: string) => void
+  frequentTags?: Tag[]
+  recentTags?: Tag[]
 }
 
 export function InputSection({
@@ -21,6 +23,8 @@ export function InputSection({
   selectedTags,
   onTagAdd,
   onTagRemove,
+  frequentTags,
+  recentTags,
 }: InputSectionProps) {
   return (
     <div className="input-section">
@@ -33,6 +37,8 @@ export function InputSection({
         selectedTags={selectedTags}
         onTagAdd={onTagAdd}
         onTagRemove={onTagRemove}
+        frequentTags={frequentTags}
+        recentTags={recentTags}
       />
     </div>
   )

--- a/src/components/TagFilter.tsx
+++ b/src/components/TagFilter.tsx
@@ -4,11 +4,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { Input } from '@/components/ui/input'
 import { TagBadge } from '@/components/TagBadge'
 import { Tag as TagIcon, Plus, Trash2 } from 'lucide-react'
-
-interface Tag {
-  id: number
-  name: string
-}
+import type { Tag } from '@/types'
 
 interface TagFilterProps {
   availableTags: Tag[]
@@ -19,6 +15,8 @@ interface TagFilterProps {
   onFilterModeChange: (mode: 'AND' | 'OR') => void
   onClearAll: () => void
   onTagDelete?: (tag: string) => void
+  frequentTags?: Tag[]
+  recentTags?: Tag[]
 }
 
 export function TagFilter({
@@ -30,6 +28,8 @@ export function TagFilter({
   onFilterModeChange,
   onClearAll,
   onTagDelete,
+  frequentTags = [],
+  recentTags = [],
 }: TagFilterProps) {
   const [open, setOpen] = React.useState(false)
   const [newTagInput, setNewTagInput] = React.useState("")
@@ -38,6 +38,23 @@ export function TagFilter({
   // 選択されていないタグのみを表示
   const unselectedTags = availableTags.filter(
     (tag) => !selectedTags.includes(tag.name)
+  )
+
+  // よく使うタグ（選択されていないもののみ）
+  const unselectedFrequentTags = frequentTags.filter(
+    (tag) => !selectedTags.includes(tag.name)
+  )
+
+  // 最近使ったタグ（選択されていないもののみ）
+  const unselectedRecentTags = recentTags.filter(
+    (tag) => !selectedTags.includes(tag.name)
+  )
+
+  // frequentとrecentに含まれないタグ
+  const frequentIds = new Set(frequentTags.map(t => t.id))
+  const recentIds = new Set(recentTags.map(t => t.id))
+  const otherTags = unselectedTags.filter(
+    (tag) => !frequentIds.has(tag.id) && !recentIds.has(tag.id)
   )
 
   const handleAddNewTag = () => {
@@ -101,12 +118,48 @@ export function TagFilter({
               </div>
             )}
 
-            {/* 既存タグ一覧 */}
-            {!managementMode && unselectedTags.length > 0 && (
+            {/* よく使うタグ */}
+            {!managementMode && unselectedFrequentTags.length > 0 && (
               <>
-                <div className="text-xs text-muted-foreground px-1">既存のタグから選択</div>
+                <div className="text-xs text-muted-foreground px-1">よく使うタグ</div>
                 <div className="flex flex-wrap gap-1">
-                  {unselectedTags.map((tag) => (
+                  {unselectedFrequentTags.map((tag) => (
+                    <TagBadge
+                      key={tag.id}
+                      tag={tag.name}
+                      onClick={(tagName) => {
+                        onTagSelect(tagName)
+                      }}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
+
+            {/* 最近使ったタグ */}
+            {!managementMode && unselectedRecentTags.length > 0 && (
+              <>
+                <div className="text-xs text-muted-foreground px-1">最近使ったタグ</div>
+                <div className="flex flex-wrap gap-1">
+                  {unselectedRecentTags.map((tag) => (
+                    <TagBadge
+                      key={tag.id}
+                      tag={tag.name}
+                      onClick={(tagName) => {
+                        onTagSelect(tagName)
+                      }}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
+
+            {/* その他のタグ */}
+            {!managementMode && otherTags.length > 0 && (
+              <>
+                <div className="text-xs text-muted-foreground px-1">その他のタグ</div>
+                <div className="flex flex-wrap gap-1">
+                  {otherTags.map((tag) => (
                     <TagBadge
                       key={tag.id}
                       tag={tag.name}

--- a/src/components/TagSelector.tsx
+++ b/src/components/TagSelector.tsx
@@ -12,6 +12,8 @@ interface TagSelectorProps {
   onTagAdd: (tag: string) => void
   onTagRemove?: (tag: string) => void
   trigger?: React.ReactNode
+  frequentTags?: Tag[]
+  recentTags?: Tag[]
 }
 
 export function TagSelector({
@@ -19,7 +21,9 @@ export function TagSelector({
   selectedTags,
   onTagAdd,
   onTagRemove,
-  trigger
+  trigger,
+  frequentTags = [],
+  recentTags = []
 }: TagSelectorProps) {
   const [open, setOpen] = useState(false)
   const [newTagInput, setNewTagInput] = useState("")
@@ -27,6 +31,23 @@ export function TagSelector({
   // 選択されていないタグのみを表示
   const unselectedTags = availableTags.filter(
     (tag) => !selectedTags.includes(tag.name)
+  )
+
+  // よく使うタグ（選択されていないもののみ）
+  const unselectedFrequentTags = frequentTags.filter(
+    (tag) => !selectedTags.includes(tag.name)
+  )
+
+  // 最近使ったタグ（選択されていないもののみ）
+  const unselectedRecentTags = recentTags.filter(
+    (tag) => !selectedTags.includes(tag.name)
+  )
+
+  // frequentとrecentに含まれないタグ
+  const frequentIds = new Set(frequentTags.map(t => t.id))
+  const recentIds = new Set(recentTags.map(t => t.id))
+  const otherTags = unselectedTags.filter(
+    (tag) => !frequentIds.has(tag.id) && !recentIds.has(tag.id)
   )
 
   const handleAddNewTag = () => {
@@ -75,12 +96,48 @@ export function TagSelector({
               </Button>
             </div>
 
-            {/* 既存タグ一覧 */}
-            {unselectedTags.length > 0 && (
+            {/* よく使うタグ */}
+            {unselectedFrequentTags.length > 0 && (
               <>
-                <div className="text-xs text-muted-foreground px-1">既存のタグから選択</div>
+                <div className="text-xs text-muted-foreground px-1">よく使うタグ</div>
                 <div className="flex flex-wrap gap-1">
-                  {unselectedTags.map((tag) => (
+                  {unselectedFrequentTags.map((tag) => (
+                    <TagBadge
+                      key={tag.id}
+                      tag={tag.name}
+                      onClick={(tagName) => {
+                        onTagAdd(tagName)
+                      }}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
+
+            {/* 最近使ったタグ */}
+            {unselectedRecentTags.length > 0 && (
+              <>
+                <div className="text-xs text-muted-foreground px-1">最近使ったタグ</div>
+                <div className="flex flex-wrap gap-1">
+                  {unselectedRecentTags.map((tag) => (
+                    <TagBadge
+                      key={tag.id}
+                      tag={tag.name}
+                      onClick={(tagName) => {
+                        onTagAdd(tagName)
+                      }}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
+
+            {/* その他のタグ */}
+            {otherTags.length > 0 && (
+              <>
+                <div className="text-xs text-muted-foreground px-1">その他のタグ</div>
+                <div className="flex flex-wrap gap-1">
+                  {otherTags.map((tag) => (
                     <TagBadge
                       key={tag.id}
                       tag={tag.name}

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -17,6 +17,8 @@ interface TimelineProps {
   replyContent: string
   replyManualTags: string[]
   expandedEntryReplies: Set<number>
+  frequentTags?: Tag[]
+  recentTags?: Tag[]
   onEditEntry: (id: number, content: string) => void
   onCancelEditEntry: () => void
   onUpdateEntry: (id: number) => void
@@ -60,6 +62,8 @@ export function Timeline({
   replyContent,
   replyManualTags,
   expandedEntryReplies,
+  frequentTags = [],
+  recentTags = [],
   onEditEntry,
   onCancelEditEntry,
   onUpdateEntry,
@@ -121,6 +125,8 @@ export function Timeline({
                   replyContent={replyContent}
                   replyManualTags={replyManualTags}
                   expandedEntryReplies={expandedEntryReplies}
+                  frequentTags={frequentTags}
+                  recentTags={recentTags}
                   onEditEntry={onEditEntry}
                   onCancelEditEntry={onCancelEditEntry}
                   onUpdateEntry={onUpdateEntry}
@@ -172,6 +178,8 @@ export function Timeline({
               replyContent={replyContent}
               replyManualTags={replyManualTags}
               expandedEntryReplies={expandedEntryReplies}
+              frequentTags={frequentTags}
+              recentTags={recentTags}
               onEditEntry={onEditEntry}
               onCancelEditEntry={onCancelEditEntry}
               onUpdateEntry={onUpdateEntry}

--- a/src/components/TimelineItemComponent.tsx
+++ b/src/components/TimelineItemComponent.tsx
@@ -18,6 +18,8 @@ interface TimelineItemComponentProps {
   replyContent: string
   replyManualTags: string[]
   expandedEntryReplies: Set<number>
+  frequentTags?: Tag[]
+  recentTags?: Tag[]
   onEditEntry: (id: number, content: string) => void
   onCancelEditEntry: () => void
   onUpdateEntry: (id: number) => void
@@ -61,6 +63,8 @@ export function TimelineItemComponent({
   replyContent,
   replyManualTags,
   expandedEntryReplies,
+  frequentTags = [],
+  recentTags = [],
   onEditEntry,
   onCancelEditEntry,
   onUpdateEntry,
@@ -132,6 +136,8 @@ export function TimelineItemComponent({
             replyContent={replyContent}
             replyManualTags={replyManualTags}
             expandedReplies={expandedEntryReplies.has(item.id)}
+            frequentTags={frequentTags}
+            recentTags={recentTags}
             onEdit={onEditEntry}
             onCancelEdit={onCancelEditEntry}
             onUpdateEntry={onUpdateEntry}

--- a/src/hooks/useTags.test.ts
+++ b/src/hooks/useTags.test.ts
@@ -7,6 +7,7 @@ import * as tagsLib from '@/lib/tags'
 vi.mock('@/lib/tags', () => ({
   getAllTags: vi.fn(),
   deleteTag: vi.fn(),
+  categorizeTagsByUsage: vi.fn().mockReturnValue({ frequent: [], recent: [], others: [] }),
 }))
 
 describe('useTags', () => {

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import Database from '@tauri-apps/plugin-sql'
-import { Tag } from '@/types'
-import { getAllTags, deleteTag } from '@/lib/tags'
+import type { Tag, CategorizedTags } from '@/types'
+import { getAllTags, deleteTag, categorizeTagsByUsage } from '@/lib/tags'
 
 interface UseTagsProps {
   database: Database | null
@@ -14,6 +14,15 @@ export function useTags({ database, loadEntries }: UseTagsProps) {
   const [availableTags, setAvailableTags] = useState<Tag[]>([])
   const [deleteTagTarget, setDeleteTagTarget] = useState<string | null>(null)
   const [deleteTagDialogOpen, setDeleteTagDialogOpen] = useState(false)
+
+  // カテゴリ分けされたタグをメモ化
+  const categorizedTags: CategorizedTags = useMemo(() => {
+    return categorizeTagsByUsage(availableTags, 5)
+  }, [availableTags])
+
+  // よく使うタグと最近使ったタグ
+  const frequentTags = categorizedTags.frequent
+  const recentTags = categorizedTags.recent
 
   const loadAvailableTags = async () => {
     if (!database) return
@@ -79,6 +88,10 @@ export function useTags({ database, loadEntries }: UseTagsProps) {
     deleteTagDialogOpen,
     setDeleteTagDialogOpen,
     deleteTagTarget,
+    // Categorized tags
+    categorizedTags,
+    frequentTags,
+    recentTags,
     // Handlers
     loadAvailableTags,
     handleTagClick,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,14 @@
 export interface Tag {
   id: number
   name: string
+  usageCount?: number
+  lastUsedAt?: string | null
+}
+
+export interface CategorizedTags {
+  frequent: Tag[]
+  recent: Tag[]
+  others: Tag[]
 }
 
 export interface Entry {


### PR DESCRIPTION
## Summary
- タグの使用統計（使用回数・最終使用日時）を追跡する機能を追加
- タグセレクターで「よく使うタグ」「最近使ったタグ」「その他のタグ」にカテゴリ分けして表示
- 既存データのマイグレーションにより、過去の使用履歴も反映

## Test plan
- [x] 新規エントリにタグを追加し、usage_countとlast_used_atが更新されることを確認
- [x] タグセレクターを開いて、カテゴリ分けが正しく表示されることを確認
- [x] よく使うタグが使用回数順に表示されることを確認
- [x] 最近使ったタグが日時順に表示されることを確認

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)