### PR TITLE
feat: エントリーのアーカイブ機能を追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -403,6 +403,72 @@ textarea::placeholder {
   background-color: #f1f8f4;
 }
 
+.archive-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 8.5rem;
+  padding: 0.4rem;
+  background-color: transparent;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  color: #999;
+  opacity: 0;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.entry-card:hover .archive-button {
+  opacity: 1;
+}
+
+.archive-button:hover {
+  background-color: #fff3e0;
+  color: #FF9800;
+}
+
+.archive-button.archived {
+  opacity: 1;
+  color: #FF9800;
+}
+
+.entry-card.archived.collapsed {
+  padding: 0.5rem 0.75rem;
+  background: transparent;
+  border: 1px dashed rgba(0, 0, 0, 0.15);
+  box-shadow: none;
+  opacity: 0.5;
+}
+
+.entry-card.archived.collapsed:hover {
+  opacity: 0.7;
+  border-color: rgba(0, 0, 0, 0.25);
+  background: rgba(0, 0, 0, 0.02);
+}
+
+.archived-preview {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.archived-icon {
+  color: #999;
+  flex-shrink: 0;
+}
+
+.archived-text {
+  font-size: 0.8rem;
+  color: #888;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* Edit Input Section */
 .edit-input-section {
   margin-top: 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -160,6 +160,7 @@ function App() {
     handleDeleteEntry,
     handleKeyDown,
     handleTogglePin,
+    handleToggleArchive,
     handleDirectUpdateEntry,
     handleDirectTagAdd,
     handleDirectTagRemove,
@@ -343,6 +344,7 @@ function App() {
           onToggleReplies={toggleEntryReplies}
           onScrollToEntry={scrollToEntry}
           onTogglePin={handleTogglePin}
+          onToggleArchive={handleToggleArchive}
           onUpdateEntryDirectly={handleDirectUpdateEntry}
           onDirectTagAdd={handleDirectTagAdd}
           onDirectTagRemove={handleDirectTagRemove}

--- a/src/components/EntryCard.tsx
+++ b/src/components/EntryCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Trash2, Pencil, X, Pin, FileCode, Type } from 'lucide-react'
+import { Trash2, Pencil, X, Pin, FileCode, Type, Archive } from 'lucide-react'
 import CustomInput from '@/components/CustomInput'
 import { TagBadge } from '@/components/TagBadge'
 import { TagSelector } from '@/components/TagSelector'
@@ -14,6 +14,7 @@ interface EntryCardProps {
   replyCount?: number
   replies?: Reply[]
   pinned?: boolean
+  archived?: boolean
   isEditing: boolean
   editContent: string
   editManualTags: string[]
@@ -40,6 +41,7 @@ interface EntryCardProps {
   onAddReply: (id: number) => void
   onToggleReplies: (id: number) => void
   onTogglePin: (id: number) => void
+  onToggleArchive: (id: number) => void
   onUpdateEntryDirectly: (entryId: number, newContent: string) => void
   onDirectTagAdd: (tag: string) => void
   onDirectTagRemove: (tag: string) => void
@@ -52,6 +54,7 @@ export function EntryCard({
   replyCount,
   replies,
   pinned,
+  archived,
   isEditing,
   editContent,
   editManualTags,
@@ -78,11 +81,34 @@ export function EntryCard({
   onAddReply,
   onToggleReplies,
   onTogglePin,
+  onToggleArchive,
   onUpdateEntryDirectly,
   onDirectTagAdd,
   onDirectTagRemove,
 }: EntryCardProps) {
   const [showMarkdown, setShowMarkdown] = useState(true)
+
+  // アーカイブ済みエントリーの1行目を取得
+  const getFirstLine = (text: string) => {
+    const firstLine = text.split('\n')[0]
+    return firstLine.length > 50 ? firstLine.substring(0, 50) + '...' : firstLine
+  }
+
+  // アーカイブ済みで折りたたまれた表示
+  if (archived) {
+    return (
+      <div className="entry-card archived collapsed">
+        <div
+          className="archived-preview"
+          onClick={() => onToggleArchive(id)}
+          title="クリックしてアーカイブを解除"
+        >
+          <Archive size={14} className="archived-icon" />
+          <span className="archived-text">{getFirstLine(content)}</span>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className={`entry-card ${pinned ? 'pinned' : ''}`}>
@@ -113,6 +139,13 @@ export function EntryCard({
         aria-label={pinned ? "ピン留めを解除" : "ピン留め"}
       >
         <Pin size={16} />
+      </button>
+      <button
+        className="archive-button"
+        onClick={() => onToggleArchive(id)}
+        aria-label="アーカイブ"
+      >
+        <Archive size={16} />
       </button>
       {isEditing ? (
         <div className="edit-input-section">

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -42,6 +42,7 @@ interface TimelineProps {
   onToggleReplies: (id: number) => void
   onScrollToEntry: (entryId: number) => void
   onTogglePin: (id: number) => void
+  onToggleArchive: (id: number) => void
   onUpdateEntryDirectly: (entryId: number, newContent: string) => void
   onDirectTagAdd: (entryId: number, tag: string) => void
   onDirectTagRemove: (entryId: number, tag: string) => void
@@ -87,6 +88,7 @@ export function Timeline({
   onToggleReplies,
   onScrollToEntry,
   onTogglePin,
+  onToggleArchive,
   onUpdateEntryDirectly,
   onDirectTagAdd,
   onDirectTagRemove,
@@ -150,6 +152,7 @@ export function Timeline({
                   onToggleReplies={onToggleReplies}
                   onScrollToEntry={onScrollToEntry}
                   onTogglePin={onTogglePin}
+                  onToggleArchive={onToggleArchive}
                   onUpdateEntryDirectly={onUpdateEntryDirectly}
                   onDirectTagAdd={onDirectTagAdd}
                   onDirectTagRemove={onDirectTagRemove}
@@ -203,6 +206,7 @@ export function Timeline({
               onToggleReplies={onToggleReplies}
               onScrollToEntry={onScrollToEntry}
               onTogglePin={onTogglePin}
+              onToggleArchive={onToggleArchive}
               onUpdateEntryDirectly={onUpdateEntryDirectly}
               onDirectTagAdd={onDirectTagAdd}
               onDirectTagRemove={onDirectTagRemove}

--- a/src/components/TimelineItemComponent.tsx
+++ b/src/components/TimelineItemComponent.tsx
@@ -43,6 +43,7 @@ interface TimelineItemComponentProps {
   onToggleReplies: (id: number) => void
   onScrollToEntry: (entryId: number) => void
   onTogglePin: (id: number) => void
+  onToggleArchive: (id: number) => void
   onUpdateEntryDirectly: (entryId: number, newContent: string) => void
   onDirectTagAdd: (entryId: number, tag: string) => void
   onDirectTagRemove: (entryId: number, tag: string) => void
@@ -88,6 +89,7 @@ export function TimelineItemComponent({
   onToggleReplies,
   onScrollToEntry,
   onTogglePin,
+  onToggleArchive,
   onUpdateEntryDirectly,
   onDirectTagAdd,
   onDirectTagRemove,
@@ -127,6 +129,7 @@ export function TimelineItemComponent({
             replyCount={item.replyCount}
             replies={item.replies}
             pinned={item.pinned}
+            archived={item.archived}
             isEditing={editingEntryId === item.id}
             editContent={editContent}
             editManualTags={editManualTags}
@@ -153,6 +156,7 @@ export function TimelineItemComponent({
             onAddReply={onAddReply}
             onToggleReplies={onToggleReplies}
             onTogglePin={onTogglePin}
+            onToggleArchive={onToggleArchive}
             onUpdateEntryDirectly={onUpdateEntryDirectly}
             onDirectTagAdd={(tag) => onDirectTagAdd(item.id, tag)}
             onDirectTagRemove={(tag) => onDirectTagRemove(item.id, tag)}

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -46,8 +46,8 @@ export function useTimeline({ database, selectedDate, selectedTags, filterMode, 
       const isSearching = searchText.trim().length > 0
       const isCrossDateQuery = isTagFiltering || isSearching
 
-      // エントリーをSQLクエリで取得（pinned状態も含める）
-      let entryQuery = 'SELECT id, content, timestamp, pinned FROM entries WHERE 1=1'
+      // エントリーをSQLクエリで取得（pinned, archived状態も含める）
+      let entryQuery = 'SELECT id, content, timestamp, pinned, archived FROM entries WHERE 1=1'
       const entryParams: (string | number)[] = []
 
       // タグフィルタリングまたは検索時以外は日付条件を追加
@@ -136,7 +136,7 @@ export function useTimeline({ database, selectedDate, selectedTags, filterMode, 
 
         if (additionalParentIds.length > 0) {
           // タグフィルタリングまたは検索時は日付条件なしで親エントリーを取得
-          let additionalParentsQuery = `SELECT id, content, timestamp, pinned FROM entries WHERE id IN (${additionalParentIds.join(',')})`
+          let additionalParentsQuery = `SELECT id, content, timestamp, pinned, archived FROM entries WHERE id IN (${additionalParentIds.join(',')})`
           const additionalParentsParams: (string | number)[] = []
 
           if (!isCrossDateQuery) {
@@ -189,7 +189,8 @@ export function useTimeline({ database, selectedDate, selectedTags, filterMode, 
           replies: entryReplies,
           replyCount: entryReplies.length,
           tags: entry.tags,
-          pinned: entry.pinned === 1
+          pinned: entry.pinned === 1,
+          archived: entry.archived === 1
         }
       })
 

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -150,6 +150,15 @@ export async function getDb() {
       )
       WHERE last_used_at IS NULL
     `)
+
+    // archivedカラムを追加（既に存在する場合はエラーを無視）
+    try {
+      await db.execute(`
+        ALTER TABLE entries ADD COLUMN archived INTEGER DEFAULT 0
+      `)
+    } catch (error) {
+      console.log('archived column already exists or migration error:', error)
+    }
   }
   return db
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface Entry {
   timestamp: string
   tags?: Tag[]
   pinned?: number
+  archived?: number
 }
 
 export interface Reply {
@@ -37,6 +38,7 @@ export interface TimelineItem {
   replyCount?: number
   tags?: Tag[]
   pinned?: boolean
+  archived?: boolean
   // reply specific fields
   replyId?: number
   entryId?: number


### PR DESCRIPTION
## Summary
- エントリーにアーカイブボタンを追加
- アーカイブ済みエントリーは折りたたんで1行表示（透明な点線枠）
- クリックでアーカイブ解除可能

## Changes
- `src/lib/database.ts`: entriesテーブルにarchivedカラムを追加
- `src/types.ts`: Entry型とTimelineItem型にarchivedフィールドを追加
- `src/hooks/useEntries.ts`: handleToggleArchive関数を追加
- `src/hooks/useTimeline.ts`: archivedフィールドの取得に対応
- `src/components/EntryCard.tsx`: アーカイブボタンと折りたたみ表示を追加
- `src/components/Timeline.tsx`, `TimelineItemComponent.tsx`: onToggleArchiveプロパティを追加
- `src/App.css`: アーカイブ済みエントリーのスタイルを追加

## Test plan
- [ ] エントリーのアーカイブボタンをクリックして折りたたみ表示になることを確認
- [ ] 折りたたまれたエントリーをクリックしてアーカイブ解除されることを確認
- [ ] アプリ再起動後もアーカイブ状態が保持されることを確認

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)