### PR TITLE
fix: フォントサイズの変更がエントリに反映されない問題を修正

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1099,7 +1099,7 @@ textarea::placeholder {
 
 /* Markdown Preview Styles */
 .markdown-preview {
-  font-size: 0.9rem;
+  font-size: var(--font-size, 0.9rem);
   color: #555;
   line-height: 1.5;
   word-wrap: break-word;


### PR DESCRIPTION
## Summary
- `.markdown-preview`クラスのフォントサイズが固定値(`0.9rem`)だったため、CSS変数`--font-size`を使用するように修正
- 設定画面でフォントサイズを変更すると、エントリのテキストにも即座に反映されるように

## Root Cause
`src/App.css`の`.markdown-preview`クラスに`font-size: 0.9rem`という固定値が設定されていたため、設定画面で変更したフォントサイズ（`--font-size` CSS変数）が上書きされていた。

## Fix
```css
/* Before */
.markdown-preview {
  font-size: 0.9rem;
}

/* After */
.markdown-preview {
  font-size: var(--font-size, 0.9rem);
}
```

## Test plan
- [ ] 設定サイドバーでフォントサイズを変更する（例: 20pt）
- [ ] エントリのテキストが即座に大きくなることを確認
- [ ] デフォルトに戻すとエントリのテキストが元のサイズに戻ることを確認

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)