### PR TITLE
feat: 返信エントリもアーカイブ可能に

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -469,6 +469,48 @@ textarea::placeholder {
   text-overflow: ellipsis;
 }
 
+/* Reply Card Archive Button */
+.reply-card .archive-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 6.5rem;
+  padding: 0.4rem;
+  background-color: transparent;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  color: #999;
+  opacity: 0;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.reply-card:hover .archive-button {
+  opacity: 1;
+}
+
+.reply-card .archive-button:hover {
+  background-color: #fff3e0;
+  color: #FF9800;
+}
+
+/* Reply Card - Archived Collapsed State */
+.reply-card.archived.collapsed {
+  padding: 0.5rem 0.75rem;
+  background: transparent;
+  border: 1px dashed rgba(0, 0, 0, 0.15);
+  box-shadow: none;
+  opacity: 0.5;
+}
+
+.reply-card.archived.collapsed:hover {
+  opacity: 0.7;
+  border-color: rgba(0, 0, 0, 0.25);
+  background: rgba(0, 0, 0, 0.02);
+}
+
 /* Edit Input Section */
 .edit-input-section {
   margin-top: 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -216,6 +216,7 @@ function App() {
     openDeleteReplyDialog,
     handleDeleteReply,
     handleDirectUpdateReply,
+    handleToggleReplyArchive,
   } = useReplies({
     database,
     timelineItems: filteredTimelineItems,
@@ -419,6 +420,10 @@ function App() {
             await handleDirectUpdateReply(replyId, newContent)
             await loadTodos()
             await loadCompletedTodos()
+          }}
+          onToggleReplyArchive={async (replyId, entryId) => {
+            await handleToggleReplyArchive(replyId, entryId)
+            await loadTodos()
           }}
         />
       </div>

--- a/src/components/ReplyCard.tsx
+++ b/src/components/ReplyCard.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
-import { Trash2, Pencil, X, FileCode, Type } from 'lucide-react'
+import { Trash2, Pencil, X, FileCode, Type, Archive } from 'lucide-react'
 import CustomInput from '@/components/CustomInput'
 import { TagBadge } from '@/components/TagBadge'
-import { truncateText } from '@/utils/textUtils'
+import { truncateText, getFirstLine } from '@/utils/textUtils'
 import { Tag } from '@/types'
 import MarkdownPreview from '@/components/MarkdownPreview'
 
@@ -15,6 +15,7 @@ interface ReplyCardProps {
     id: number
     content: string
   }
+  archived?: boolean
   isEditing: boolean
   editContent: string
   editManualTags: string[]
@@ -30,6 +31,7 @@ interface ReplyCardProps {
   onTagClick: (tag: string) => void
   onScrollToEntry: (entryId: number) => void
   onUpdateReplyDirectly: (replyId: number, newContent: string) => void
+  onToggleArchive: (replyId: number, entryId: number) => void
 }
 
 export function ReplyCard({
@@ -38,6 +40,7 @@ export function ReplyCard({
   content,
   tags,
   parentEntry,
+  archived,
   isEditing,
   editContent,
   editManualTags,
@@ -53,11 +56,35 @@ export function ReplyCard({
   onTagClick,
   onScrollToEntry,
   onUpdateReplyDirectly,
+  onToggleArchive,
 }: ReplyCardProps) {
   const [showMarkdown, setShowMarkdown] = useState(true)
 
+  // アーカイブ済みの場合は折りたたみ表示
+  if (archived) {
+    return (
+      <div className="reply-card archived collapsed">
+        <div
+          className="archived-preview"
+          onClick={() => onToggleArchive(replyId, entryId)}
+          title="クリックしてアーカイブを解除"
+        >
+          <Archive size={14} className="archived-icon" />
+          <span className="archived-text">{getFirstLine(content)}</span>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="reply-card">
+      <button
+        className="archive-button"
+        onClick={() => onToggleArchive(replyId, entryId)}
+        aria-label="アーカイブ"
+      >
+        <Archive size={16} />
+      </button>
       <button
         className="edit-button"
         onClick={() => isEditing ? onCancelEdit() : onEdit(replyId, content)}

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -47,6 +47,7 @@ interface TimelineProps {
   onDirectTagAdd: (entryId: number, tag: string) => void
   onDirectTagRemove: (entryId: number, tag: string) => void
   onUpdateReplyDirectly: (replyId: number, newContent: string) => void
+  onToggleReplyArchive: (replyId: number, entryId: number) => void
 }
 
 export function Timeline({
@@ -94,6 +95,7 @@ export function Timeline({
   onDirectTagAdd,
   onDirectTagRemove,
   onUpdateReplyDirectly,
+  onToggleReplyArchive,
 }: TimelineProps) {
   // タグフィルタリング時は日付別にグループ化
   const groupedItems = isTagFiltering ? groupTimelineItemsByDate(timelineItems) : null
@@ -159,6 +161,7 @@ export function Timeline({
                   onDirectTagAdd={onDirectTagAdd}
                   onDirectTagRemove={onDirectTagRemove}
                   onUpdateReplyDirectly={onUpdateReplyDirectly}
+                  onToggleReplyArchive={onToggleReplyArchive}
                 />
               ))}
             </div>
@@ -214,6 +217,7 @@ export function Timeline({
               onDirectTagAdd={onDirectTagAdd}
               onDirectTagRemove={onDirectTagRemove}
               onUpdateReplyDirectly={onUpdateReplyDirectly}
+              onToggleReplyArchive={onToggleReplyArchive}
             />
           ))}
         </div>

--- a/src/components/TimelineItemComponent.tsx
+++ b/src/components/TimelineItemComponent.tsx
@@ -48,6 +48,7 @@ interface TimelineItemComponentProps {
   onDirectTagAdd: (entryId: number, tag: string) => void
   onDirectTagRemove: (entryId: number, tag: string) => void
   onUpdateReplyDirectly: (replyId: number, newContent: string) => void
+  onToggleReplyArchive: (replyId: number, entryId: number) => void
 }
 
 export function TimelineItemComponent({
@@ -95,6 +96,7 @@ export function TimelineItemComponent({
   onDirectTagAdd,
   onDirectTagRemove,
   onUpdateReplyDirectly,
+  onToggleReplyArchive,
 }: TimelineItemComponentProps) {
   const itemDate = new Date(item.timestamp)
   const day = itemDate.getDate()
@@ -170,6 +172,7 @@ export function TimelineItemComponent({
             content={item.content}
             tags={item.tags}
             parentEntry={item.parentEntry}
+            archived={item.replyArchived}
             isEditing={editingReplyId === item.replyId}
             editContent={editReplyContent}
             editManualTags={editReplyManualTags}
@@ -185,6 +188,7 @@ export function TimelineItemComponent({
             onTagClick={onTagClick}
             onScrollToEntry={onScrollToEntry}
             onUpdateReplyDirectly={onUpdateReplyDirectly}
+            onToggleArchive={onToggleReplyArchive}
           />
         )}
       </div>

--- a/src/hooks/useEntries.ts
+++ b/src/hooks/useEntries.ts
@@ -288,12 +288,23 @@ export function useEntries({ database, timelineItems, setTimelineItems, loadAvai
         [newArchived, entryId]
       )
 
-      // stateを更新
-      setTimelineItems(timelineItems.map(item =>
-        item.type === 'entry' && item.id === entryId
-          ? { ...item, archived: newArchived === 1 }
-          : item
-      ))
+      // stateを更新（エントリー自体と、そのエントリーを親とする返信のparentEntry.archivedも更新）
+      setTimelineItems(timelineItems.map(item => {
+        if (item.type === 'entry' && item.id === entryId) {
+          return { ...item, archived: newArchived === 1 }
+        }
+        // 返信の場合、親エントリーのアーカイブ状態も更新
+        if (item.type === 'reply' && item.entryId === entryId && item.parentEntry) {
+          return {
+            ...item,
+            parentEntry: {
+              ...item.parentEntry,
+              archived: newArchived === 1
+            }
+          }
+        }
+        return item
+      }))
     } catch (error) {
       console.error('アーカイブ状態の切り替えに失敗しました:', error)
     }

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -107,7 +107,7 @@ export function useTimeline({ database, selectedDate, selectedTags, filterMode, 
 
       if (selectedTags.length > 0 || isSearching) {
         // タグフィルタまたは検索が有効な場合：返信もフィルタリング
-        let replyQuery = 'SELECT id, entry_id, content, timestamp FROM replies WHERE 1=1'
+        let replyQuery = 'SELECT id, entry_id, content, timestamp, archived FROM replies WHERE 1=1'
         const replyParams: (string | number)[] = []
 
         if (replyTagFilter.condition) {
@@ -169,7 +169,7 @@ export function useTimeline({ database, selectedDate, selectedTags, filterMode, 
         }
 
         replies = await database.select<Reply[]>(
-          `SELECT id, entry_id, content, timestamp FROM replies WHERE entry_id IN (${entryIds.join(',')})`,
+          `SELECT id, entry_id, content, timestamp, archived FROM replies WHERE entry_id IN (${entryIds.join(',')})`,
           []
         )
 
@@ -206,9 +206,11 @@ export function useTimeline({ database, selectedDate, selectedTags, filterMode, 
           content: reply.content,
           timestamp: reply.timestamp,
           tags: reply.tags,
+          replyArchived: reply.archived === 1,
           parentEntry: parentEntry ? {
             id: parentEntry.id,
-            content: parentEntry.content
+            content: parentEntry.content,
+            archived: parentEntry.archived === 1
           } : undefined
         }
       })

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -43,12 +43,13 @@ export function useTodos({ database }: UseTodosProps) {
         })
       }
 
-      // 返信からもTODOを取得（親エントリーがアーカイブされていないもの）
+      // 返信からもTODOを取得（親エントリーがアーカイブされていないもの、かつ返信自体もアーカイブされていないもの）
       const replies = await database.select<(Reply & { entry_id: number })[]>(
         `SELECT r.id, r.entry_id, r.content
          FROM replies r
          JOIN entries e ON r.entry_id = e.id
          WHERE (e.archived = 0 OR e.archived IS NULL)
+         AND (r.archived = 0 OR r.archived IS NULL)
          AND (r.content LIKE ? OR r.content LIKE ?)`,
         ['%[ ]%', '%[/]%']
       )

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -168,6 +168,15 @@ export async function getDb() {
     } catch (error) {
       console.log('is_current column already exists or migration error:', error)
     }
+
+    // 返信テーブルにarchivedカラムを追加（既に存在する場合はエラーを無視）
+    try {
+      await db.execute(`
+        ALTER TABLE replies ADD COLUMN archived INTEGER DEFAULT 0
+      `)
+    } catch (error) {
+      console.log('replies.archived column already exists or migration error:', error)
+    }
   }
   return db
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export interface Reply {
   content: string
   timestamp: string
   tags?: Tag[]
+  archived?: number
 }
 
 export interface TodoItem {
@@ -63,5 +64,7 @@ export interface TimelineItem {
   parentEntry?: {
     id: number
     content: string
+    archived?: boolean
   }
+  replyArchived?: boolean
 }


### PR DESCRIPTION
## Summary
- 返信エントリにアーカイブ機能を追加
- アーカイブされた返信は折りたたみ表示（通常エントリと同じUIパターン）
- アーカイブされた返信のTODOはTODOリストから除外

## Changes
- `replies`テーブルに`archived`カラムを追加
- `ReplyCard`にアーカイブボタンと折りたたみ表示を実装
- 返信のアーカイブは親エントリと独立して管理

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)