### PR TITLE
feat: 「今何してる？」リストにドラッグ&ドロップ並び替え機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -748,6 +751,59 @@
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
       "license": "MIT"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.51.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   },
   "homepage": "https://github.com/FScoward/funhou#readme",
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/src/App.css
+++ b/src/App.css
@@ -1926,6 +1926,43 @@ textarea::placeholder {
   color: var(--doing-checkbox-color, #f59e0b);
 }
 
+/* ドラッグハンドル */
+.doing-list-item-drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: transparent;
+  cursor: grab;
+  color: var(--text-muted, #999);
+  opacity: 0;
+  transition: opacity 0.2s ease, color 0.15s ease;
+  flex-shrink: 0;
+  padding: 0;
+}
+
+.doing-list-item:hover .doing-list-item-drag-handle {
+  opacity: 0.6;
+}
+
+.doing-list-item-drag-handle:hover {
+  opacity: 1;
+  color: var(--doing-checkbox-color, #f59e0b);
+}
+
+.doing-list-item-drag-handle:active {
+  cursor: grabbing;
+}
+
+/* ドラッグ中のアイテム */
+.doing-list-item.is-dragging {
+  opacity: 0.5;
+  background-color: rgba(245, 158, 11, 0.1);
+  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.2);
+}
+
 /* 空状態 */
 .current-activity-empty {
   text-align: center;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -146,6 +146,8 @@ function App() {
     isLoading: isTodosLoading,
     updateEntryLine,
     updateReplyLine,
+    saveDoingOrder,
+    reorderDoingTodos,
   } = useTodos({ database })
 
   // 完了タスク
@@ -350,6 +352,12 @@ function App() {
             }
             await loadTodos()
             await loadCompletedTodos()
+          }}
+          onReorder={async (activeId, overId) => {
+            const reorderedDoingTodos = reorderDoingTodos(activeId, overId)
+            if (reorderedDoingTodos) {
+              await saveDoingOrder(reorderedDoingTodos)
+            }
           }}
         />
 

--- a/src/components/SortableDoingItem.tsx
+++ b/src/components/SortableDoingItem.tsx
@@ -1,0 +1,76 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { GripVertical, ExternalLink } from 'lucide-react'
+import { TodoItem, getTodoUniqueId } from '@/types'
+
+interface SortableDoingItemProps {
+  todo: TodoItem
+  onStatusChange?: (todo: TodoItem, newStatus: 'x') => Promise<void>
+  onScrollToEntry?: (entryId: number) => void
+  onScrollToReply?: (replyId: number) => void
+}
+
+export function SortableDoingItem({
+  todo,
+  onStatusChange,
+  onScrollToEntry,
+  onScrollToReply,
+}: SortableDoingItemProps) {
+  const uniqueId = getTodoUniqueId(todo)
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: uniqueId })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`doing-list-item ${isDragging ? 'is-dragging' : ''}`}
+    >
+      <button
+        className="doing-list-item-drag-handle"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical size={14} />
+      </button>
+
+      {onStatusChange && (
+        <button
+          className="doing-list-item-checkbox"
+          onClick={() => onStatusChange(todo, 'x')}
+          title="完了にする"
+        />
+      )}
+      <span className="doing-list-item-text">{todo.text}</span>
+      {todo.replyId && onScrollToReply ? (
+        <button
+          className="doing-list-item-jump"
+          onClick={() => onScrollToReply(todo.replyId!)}
+          title="返信に移動"
+        >
+          <ExternalLink size={14} />
+        </button>
+      ) : onScrollToEntry && (
+        <button
+          className="doing-list-item-jump"
+          onClick={() => onScrollToEntry(todo.entryId)}
+          title="エントリーに移動"
+        >
+          <ExternalLink size={14} />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -177,6 +177,22 @@ export async function getDb() {
     } catch (error) {
       console.log('replies.archived column already exists or migration error:', error)
     }
+
+    // DOINGタスクの並び順テーブルを作成
+    await db.execute(`
+      CREATE TABLE IF NOT EXISTS doing_order (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        entry_id INTEGER NOT NULL,
+        reply_id INTEGER,
+        line_index INTEGER NOT NULL,
+        sort_order INTEGER NOT NULL,
+        UNIQUE(entry_id, reply_id, line_index)
+      )
+    `)
+
+    await db.execute(`
+      CREATE INDEX IF NOT EXISTS idx_doing_order_sort ON doing_order(sort_order)
+    `)
   }
   return db
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,11 @@ export interface TodoItem {
   status: ' ' | '/'    // 未完了 or Doing
 }
 
+// TodoItemのユニークIDを生成（ドラッグ&ドロップ用）
+export function getTodoUniqueId(todo: TodoItem): string {
+  return `${todo.replyId ?? todo.entryId}-${todo.lineIndex}`
+}
+
 export interface CompletedTodoItem {
   entryId: number        // 元のエントリーID
   lineIndex: number      // エントリー内の行番号（1始まり）


### PR DESCRIPTION
## Summary
- @dnd-kit/core, @dnd-kit/sortable, @dnd-kit/utilitiesを導入してドラッグ&ドロップ機能を実装
- doing_orderテーブルを追加して順序をSQLiteに永続化
- SortableDoingItemコンポーネントを新規作成し、CurrentActivitySectionにDnDContextを統合
- キーボード操作にも対応

## Test plan
- [ ] DOINGタスクが2つ以上ある状態でドラッグハンドルをドラッグして並び替えできることを確認
- [ ] 並び替え後、アプリを再起動しても順序が維持されていることを確認
- [ ] タスクを完了にした後も他のタスクの順序が維持されることを確認
- [ ] キーボード（Tab + Space + 矢印キー）で並び替えできることを確認

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)