### PR TITLE
feat: 日次サマリー機能を追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2963,3 +2963,314 @@ textarea::placeholder {
   border-radius: 50%;
   border: 2px solid white;
 }
+
+/* ========================================
+   Daily Summary Sidebar - 日次サマリーサイドバー
+   ======================================== */
+
+/* トグルボタン - 左側に配置 - Liquid Glass Style */
+.summary-sidebar-toggle-fab {
+  position: fixed;
+  top: 8rem;
+  left: 1rem;
+  width: 40px;
+  height: 40px;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.4) 0%,
+    rgba(255, 255, 255, 0.1) 50%,
+    rgba(255, 255, 255, 0.2) 100%
+  );
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.08),
+    0 2px 4px rgba(0, 0, 0, 0.04),
+    inset 0 1px 2px rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 999;
+  color: var(--summary-primary, #9333ea);
+}
+
+.summary-sidebar-toggle-fab:hover {
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.5) 0%,
+    rgba(255, 255, 255, 0.2) 50%,
+    rgba(255, 255, 255, 0.3) 100%
+  );
+  transform: scale(1.05);
+  box-shadow:
+    0 6px 16px rgba(0, 0, 0, 0.12),
+    0 0 16px var(--summary-primary-light, rgba(147, 51, 234, 0.3)),
+    inset 0 1px 2px rgba(255, 255, 255, 0.6);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.summary-sidebar-toggle-fab:active {
+  transform: scale(0.95);
+}
+
+/* サイドバー本体 */
+.summary-sidebar-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 400px;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.85) 0%,
+    rgba(255, 255, 255, 0.75) 100%
+  );
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  box-shadow: 4px 0 24px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
+  overflow-y: auto;
+  transition: transform 0.3s ease-in-out;
+  border-radius: 0 24px 24px 0;
+  z-index: 1001;
+}
+
+.summary-sidebar-drawer.open {
+  transform: translateX(0);
+}
+
+.summary-sidebar-drawer.closed {
+  transform: translateX(-100%);
+  pointer-events: none;
+}
+
+/* 閉じるボタン */
+.summary-sidebar-drawer .sidebar-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+}
+
+/* オーバーレイ */
+.summary-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+}
+
+/* ヘッダー */
+.summary-sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.75rem;
+  padding-right: 2.5rem;
+  border-bottom: 2px solid var(--summary-primary, #9333ea);
+  color: var(--summary-primary, #9333ea);
+}
+
+.summary-sidebar-header h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+  flex: 1;
+}
+
+/* 日付表示 */
+.summary-sidebar-date {
+  font-size: 0.9rem;
+  color: #666;
+  margin-bottom: 1rem;
+}
+
+/* アクションボタン */
+.summary-sidebar-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.summary-generate-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: linear-gradient(135deg, var(--summary-primary, #9333ea), #7c3aed);
+  color: white;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+
+.summary-generate-btn:hover:not(:disabled) {
+  background: linear-gradient(135deg, #7c3aed, #6d28d9);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(147, 51, 234, 0.3);
+}
+
+.summary-generate-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.summary-generate-btn .spinning {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.summary-copy-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  cursor: pointer;
+  color: #666;
+  transition: all 0.2s;
+}
+
+.summary-copy-btn:hover {
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--summary-primary, #9333ea);
+}
+
+/* コンテンツエリア */
+.summary-sidebar-content {
+  flex: 1;
+}
+
+/* ローディング */
+.summary-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1rem;
+  color: #666;
+}
+
+.summary-loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid rgba(147, 51, 234, 0.2);
+  border-top-color: var(--summary-primary, #9333ea);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 1rem;
+}
+
+.summary-loading p {
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+/* 結果表示 */
+.summary-result {
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 16px;
+  padding: 1rem;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.summary-result .markdown-preview {
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.summary-result .markdown-preview ul {
+  padding-left: 1.5rem;
+  margin: 0.5rem 0;
+}
+
+.summary-result .markdown-preview li {
+  margin: 0.5rem 0;
+}
+
+/* 空の状態 */
+.summary-empty {
+  color: #999;
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 3rem 1rem;
+}
+
+.summary-empty p {
+  margin: 0;
+}
+
+/* セクション */
+.summary-section {
+  margin-bottom: 1.5rem;
+}
+
+.summary-section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  color: #555;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.summary-section-header span {
+  flex: 1;
+}
+
+.summary-section-header .summary-generate-btn {
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+}
+
+.summary-copy-btn.small {
+  width: 28px;
+  height: 28px;
+}
+
+/* エントリー一覧プレビュー */
+.summary-entries-preview {
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 12px;
+  padding: 0.75rem;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.summary-entries-preview .markdown-preview {
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+/* 小さい空の状態 */
+.summary-empty-small {
+  color: #999;
+  font-size: 0.8rem;
+  text-align: center;
+  padding: 1.5rem 1rem;
+}
+
+.summary-empty-small p {
+  margin: 0;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { useIncompleteTodos } from '@/hooks/useIncompleteTodos'
 import { CurrentActivitySection } from '@/components/CurrentActivitySection'
 import { CompletedTasksSidebar } from '@/components/CompletedTasksSidebar'
 import { IncompleteTasksSidebar } from '@/components/IncompleteTasksSidebar'
+import { DailySummarySidebar } from '@/components/DailySummarySidebar'
 import { getSettings, applyFont, applyFontSize } from '@/lib/settings'
 import { applyTheme, ThemeVariant } from '@/lib/themes'
 import { onClaudeSessionFinished } from '@/lib/claudeLogs'
@@ -33,6 +34,7 @@ function App() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [doneSidebarOpen, setDoneSidebarOpen] = useState(false)
   const [incompleteSidebarOpen, setIncompleteSidebarOpen] = useState(false)
+  const [summarySidebarOpen, setSummarySidebarOpen] = useState(false)
   const [searchText, setSearchText] = useState('')
   const [ollamaEnabled, setOllamaEnabled] = useState(false)
   const [ollamaModel, setOllamaModel] = useState('gemma3:4b')
@@ -552,6 +554,14 @@ function App() {
         }}
         isOpen={incompleteSidebarOpen}
         onToggle={() => setIncompleteSidebarOpen(!incompleteSidebarOpen)}
+      />
+
+      <DailySummarySidebar
+        timelineItems={filteredTimelineItems}
+        selectedDate={selectedDate}
+        ollamaModel={ollamaModel}
+        isOpen={summarySidebarOpen}
+        onToggle={() => setSummarySidebarOpen(!summarySidebarOpen)}
       />
 
       <DeleteConfirmDialogs

--- a/src/components/DailySummarySidebar.tsx
+++ b/src/components/DailySummarySidebar.tsx
@@ -1,0 +1,212 @@
+import { useState, useCallback, useMemo } from 'react'
+import { Sparkles, ChevronLeft, RefreshCw, Copy, Check, FileText } from 'lucide-react'
+import MarkdownPreview from '@/components/MarkdownPreview'
+import { TimelineItem } from '@/types'
+import { tryGenerateDailySummary } from '@/lib/ollama'
+import { formatDateWithWeekday } from '@/utils/dateUtils'
+
+interface DailySummarySidebarProps {
+  timelineItems: TimelineItem[]
+  selectedDate: Date
+  ollamaModel: string
+  isOpen: boolean
+  onToggle: () => void
+}
+
+export function DailySummarySidebar({
+  timelineItems,
+  selectedDate,
+  ollamaModel,
+  isOpen,
+  onToggle
+}: DailySummarySidebarProps) {
+  const [summary, setSummary] = useState<string>('')
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [copiedSummary, setCopiedSummary] = useState(false)
+  const [copiedEntries, setCopiedEntries] = useState(false)
+
+  // エントリー一覧テキストを生成
+  const entriesText = useMemo(() => {
+    const contents: string[] = []
+
+    for (const item of timelineItems) {
+      if (item.type === 'entry') {
+        contents.push(item.content)
+        if (item.replies) {
+          for (const reply of item.replies) {
+            contents.push(reply.content)
+          }
+        }
+      }
+    }
+
+    return contents.join('\n---\n')
+  }, [timelineItems])
+
+  const generateSummary = useCallback(async () => {
+    setIsGenerating(true)
+    setSummary('')
+
+    // エントリーとリプライのコンテンツを収集
+    const contents: string[] = []
+
+    for (const item of timelineItems) {
+      if (item.type === 'entry') {
+        contents.push(item.content)
+        // リプライも収集
+        if (item.replies) {
+          for (const reply of item.replies) {
+            contents.push(reply.content)
+          }
+        }
+      }
+    }
+
+    if (contents.length === 0) {
+      setSummary('まとめる内容がありません。今日の分報を追加してください。')
+      setIsGenerating(false)
+      return
+    }
+
+    const result = await tryGenerateDailySummary(contents, ollamaModel, (error) => {
+      console.error('サマリー生成エラー:', error)
+    })
+
+    setSummary(result)
+    setIsGenerating(false)
+  }, [timelineItems, ollamaModel])
+
+  const handleCopySummary = useCallback(async () => {
+    if (!summary) return
+    try {
+      await navigator.clipboard.writeText(summary)
+      setCopiedSummary(true)
+      setTimeout(() => setCopiedSummary(false), 2000)
+    } catch (error) {
+      console.error('コピーに失敗しました:', error)
+    }
+  }, [summary])
+
+  const handleCopyEntries = useCallback(async () => {
+    if (!entriesText) return
+    try {
+      await navigator.clipboard.writeText(entriesText)
+      setCopiedEntries(true)
+      setTimeout(() => setCopiedEntries(false), 2000)
+    } catch (error) {
+      console.error('コピーに失敗しました:', error)
+    }
+  }, [entriesText])
+
+  return (
+    <>
+      {/* トグルボタン（常に表示） */}
+      {!isOpen && (
+        <button
+          className="summary-sidebar-toggle-fab"
+          onClick={onToggle}
+          aria-label="日次サマリーを開く"
+        >
+          <Sparkles size={14} />
+        </button>
+      )}
+
+      {/* オーバーレイ */}
+      {isOpen && (
+        <div
+          className="sidebar-overlay summary-overlay"
+          onClick={onToggle}
+          aria-label="サイドバーを閉じる"
+        />
+      )}
+
+      {/* Drawerサイドバー */}
+      <aside className={`summary-sidebar-drawer ${isOpen ? 'open' : 'closed'}`}>
+        <button
+          className="sidebar-close"
+          onClick={onToggle}
+          aria-label="サイドバーを閉じる"
+        >
+          <ChevronLeft size={16} />
+        </button>
+
+        <div className="summary-sidebar-header">
+          <Sparkles size={18} />
+          <h2>日次サマリー</h2>
+        </div>
+
+        <div className="summary-sidebar-date">
+          {formatDateWithWeekday(selectedDate)}
+        </div>
+
+        {/* エントリー一覧セクション */}
+        <div className="summary-section">
+          <div className="summary-section-header">
+            <FileText size={16} />
+            <span>エントリー一覧</span>
+            {entriesText && (
+              <button
+                className="summary-copy-btn small"
+                onClick={handleCopyEntries}
+                title="エントリー一覧をコピー"
+              >
+                {copiedEntries ? <Check size={12} /> : <Copy size={12} />}
+              </button>
+            )}
+          </div>
+          {entriesText ? (
+            <div className="summary-entries-preview">
+              <MarkdownPreview content={entriesText} />
+            </div>
+          ) : (
+            <div className="summary-empty-small">
+              <p>エントリーがありません</p>
+            </div>
+          )}
+        </div>
+
+        {/* サマリーセクション */}
+        <div className="summary-section">
+          <div className="summary-section-header">
+            <Sparkles size={16} />
+            <span>AIサマリー</span>
+            <button
+              className="summary-generate-btn"
+              onClick={generateSummary}
+              disabled={isGenerating}
+            >
+              <RefreshCw size={12} className={isGenerating ? 'spinning' : ''} />
+              {isGenerating ? '生成中...' : '生成'}
+            </button>
+            {summary && !isGenerating && (
+              <button
+                className="summary-copy-btn small"
+                onClick={handleCopySummary}
+                title="サマリーをコピー"
+              >
+                {copiedSummary ? <Check size={12} /> : <Copy size={12} />}
+              </button>
+            )}
+          </div>
+
+          <div className="summary-sidebar-content">
+            {isGenerating ? (
+              <div className="summary-loading">
+                <div className="summary-loading-spinner" />
+                <p>AIがまとめを生成しています...</p>
+              </div>
+            ) : summary ? (
+              <div className="summary-result">
+                <MarkdownPreview content={summary} />
+              </div>
+            ) : (
+              <div className="summary-empty-small">
+                <p>「生成」ボタンを押すとAIがまとめます</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </aside>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- Ollamaを使用してその日のエントリー・リプライをAIがまとめる機能を追加
- 左側サイドバーにエントリー一覧とAIサマリーを表示
- エントリー一覧・サマリーそれぞれにコピーボタンを追加

Closes #91

## Test plan
- [ ] 左側のスパークルアイコンをクリックしてサイドバーが開くことを確認
- [ ] エントリー一覧が表示されることを確認
- [ ] 「生成」ボタンでAIサマリーが生成されることを確認（Ollama起動必須）
- [ ] エントリー一覧・サマリーのコピーボタンが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)