### PR TITLE
feat: 返信タスクを親エントリの子タスクとして表示

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1852,6 +1852,19 @@ textarea::placeholder {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  position: relative;
+  padding-left: 1.5rem;
+}
+
+/* SVG接続線（左レーン） */
+.doing-list-lines {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
 }
 
 .doing-list-item {
@@ -1861,6 +1874,9 @@ textarea::placeholder {
   padding: 0.4rem 0.5rem;
   border-radius: 8px;
   transition: background-color 0.15s;
+  position: relative;
+  z-index: 1;
+  background: var(--glass-bg, rgba(255, 255, 255, 0.8));
 }
 
 .doing-list-item:hover {
@@ -1871,42 +1887,28 @@ textarea::placeholder {
 .doing-list-item-checkbox {
   appearance: none;
   -webkit-appearance: none;
-  width: 1.25em;
-  height: 1.25em;
-  border: 2.5px solid var(--doing-checkbox-color, #f59e0b);
-  border-radius: 7px;
-  background: linear-gradient(
-    135deg,
-    var(--doing-checkbox-bg, rgba(245, 158, 11, 0.25)) 0%,
-    rgba(255, 255, 255, 0.15) 100%
-  );
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid var(--parent-color, #f59e0b);
+  border-radius: 50%;
+  background: transparent;
   position: relative;
   cursor: pointer;
   flex-shrink: 0;
-  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow:
-    0 3px 8px rgba(245, 158, 11, 0.25),
-    inset 0 1px 3px rgba(255, 255, 255, 0.4);
+  transition: all 0.2s ease;
 }
 
-/* スラッシュマーク（進行中の印） */
+/* 中央のドット（進行中の印） */
 .doing-list-item-checkbox::after {
   content: '';
   position: absolute;
   top: 50%;
-  left: 18%;
-  right: 18%;
-  height: 3px;
-  background: linear-gradient(
-    90deg,
-    var(--doing-checkbox-color, #f59e0b) 0%,
-    color-mix(in srgb, var(--doing-checkbox-color, #f59e0b), white 30%) 100%
-  );
-  transform: translateY(-50%) rotate(-45deg);
-  border-radius: 2px;
-  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.2));
+  left: 50%;
+  width: 6px;
+  height: 6px;
+  background: var(--parent-color, #f59e0b);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .doing-list-item-checkbox:hover {
@@ -1946,7 +1948,6 @@ textarea::placeholder {
 }
 
 .doing-list-item-text {
-  flex: 1;
   font-size: 0.9rem;
   line-height: 1.4;
   word-break: break-word;
@@ -2010,6 +2011,22 @@ textarea::placeholder {
   opacity: 0.5;
   background-color: rgba(245, 158, 11, 0.1);
   box-shadow: 0 4px 12px rgba(245, 158, 11, 0.2);
+}
+
+/* 子タスクのインデント */
+.doing-list-item.is-child {
+  margin-left: 1.5rem;
+}
+
+/* 子タスクバッジ */
+.doing-list-item-badge {
+  font-size: 0.65rem;
+  padding: 0.1rem 0.4rem;
+  background: var(--parent-color, #f59e0b);
+  color: white;
+  border-radius: 10px;
+  font-weight: 500;
+  flex-shrink: 0;
 }
 
 /* 空状態 */

--- a/src/components/CurrentActivitySection.tsx
+++ b/src/components/CurrentActivitySection.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useRef, useState, useEffect, useCallback } from 'react'
 import { Sparkles } from 'lucide-react'
 import { TodoItem, getTodoUniqueId } from '@/types'
 import {
@@ -16,6 +17,11 @@ import {
 } from '@dnd-kit/sortable'
 import { SortableDoingItem } from './SortableDoingItem'
 
+// 親エントリIDから色相を生成
+function getHueFromEntryId(entryId: number): number {
+  return (entryId * 137.5) % 360
+}
+
 interface CurrentActivitySectionProps {
   isLoading?: boolean
   todoItems?: TodoItem[]
@@ -33,8 +39,118 @@ export function CurrentActivitySection({
   onStatusChange,
   onReorder,
 }: CurrentActivitySectionProps) {
-  // DOINGのみフィルタリング
-  const doingTodos = todoItems.filter(todo => todo.status === '/')
+  const listRef = useRef<HTMLDivElement>(null)
+  const [curves, setCurves] = useState<Array<{ path: string; color: string }>>([])
+
+  // DOINGのみフィルタリングし、親子関係を計算
+  const doingTodos = useMemo(() => {
+    const filtered = todoItems.filter(todo => todo.status === '/')
+
+    // entryIdごとに子タスクの数をカウント
+    const childCountByEntry = new Map<number, number>()
+    filtered.forEach(todo => {
+      if (todo.replyId) {
+        childCountByEntry.set(todo.entryId, (childCountByEntry.get(todo.entryId) || 0) + 1)
+      }
+    })
+
+    // 親子情報を付与
+    return filtered.map(todo => ({
+      ...todo,
+      childCount: !todo.replyId ? childCountByEntry.get(todo.entryId) : undefined,
+    }))
+  }, [todoItems])
+
+  // 線の位置を計算（左側レーンを通る）
+  const updateLines = useCallback(() => {
+    if (!listRef.current) return
+
+    const container = listRef.current
+    const containerRect = container.getBoundingClientRect()
+    const items = container.querySelectorAll('.doing-list-item')
+
+    // 親タスクの位置を記録（チェックボックスのx座標も含む）
+    const parentPositions = new Map<number, { x: number; y: number; color: string }>()
+    // 子タスクの位置を記録
+    const childPositions: Array<{ entryId: number; x: number; y: number }> = []
+
+    // 最初のパス: 位置を収集
+    items.forEach((item) => {
+      const entryId = parseInt(item.getAttribute('data-entry-id') || '0')
+      const isChild = item.classList.contains('is-child')
+      const checkbox = item.querySelector('.doing-list-item-checkbox')
+      const checkboxRect = checkbox?.getBoundingClientRect()
+
+      if (!checkboxRect) return
+
+      const y = checkboxRect.top - containerRect.top + checkboxRect.height / 2
+      const x = checkboxRect.left - containerRect.left + checkboxRect.width / 2
+
+      if (!isChild) {
+        const hue = getHueFromEntryId(entryId)
+        parentPositions.set(entryId, { x, y, color: `hsl(${hue}, 75%, 40%)` })
+      } else {
+        childPositions.push({ entryId, x, y })
+      }
+    })
+
+    // 線を生成（親のチェックボックスから子のチェックボックスへ）
+    const newCurves: Array<{ path: string; color: string }> = []
+
+    // 子を持つ親のリストを作成（レーン位置を決めるため）
+    const parentsWithChildren: number[] = []
+    parentPositions.forEach((_, entryId) => {
+      const hasChildren = childPositions.some(c => c.entryId === entryId)
+      if (hasChildren) {
+        parentsWithChildren.push(entryId)
+      }
+    })
+
+    // 各親について、子タスクへの線を描画
+    parentPositions.forEach((parent, entryId) => {
+      const children = childPositions.filter(c => c.entryId === entryId)
+      if (children.length === 0) return
+
+      // このエントリのレーンインデックス（被らないように）
+      const laneIndex = parentsWithChildren.indexOf(entryId)
+      const laneOffset = laneIndex * 10 // 各レーンは10pxずつずらす
+
+      // 各子へのL字型の線
+      children.forEach(child => {
+        const checkboxRadius = 8 // チェックボックスの半径（1rem / 2 = 8px）
+
+        // 親のチェックボックスの左端
+        const startX = parent.x - checkboxRadius
+        const startY = parent.y
+
+        // 子のチェックボックスの左端
+        const endX = child.x - checkboxRadius
+        const endY = child.y
+
+        // L字型：親から左へ → 下へ → 子へ（レーンオフセットで被らないように）
+        const laneX = Math.min(startX, endX) - 12 - laneOffset
+
+        const path = `M ${startX} ${startY} L ${laneX} ${startY} L ${laneX} ${endY} L ${endX} ${endY}`
+
+        newCurves.push({
+          path,
+          color: parent.color,
+        })
+      })
+    })
+
+    setCurves(newCurves)
+  }, [])
+
+  useEffect(() => {
+    updateLines()
+    // ResizeObserverで監視
+    const observer = new ResizeObserver(updateLines)
+    if (listRef.current) {
+      observer.observe(listRef.current)
+    }
+    return () => observer.disconnect()
+  }, [doingTodos, updateLines])
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -53,6 +169,8 @@ export function CurrentActivitySection({
     if (over && active.id !== over.id && onReorder) {
       await onReorder(active.id as string, over.id as string)
     }
+    // 並び替え後に線を更新
+    setTimeout(updateLines, 50)
   }
 
   if (isLoading) {
@@ -87,7 +205,20 @@ export function CurrentActivitySection({
               items={doingTodos.map(getTodoUniqueId)}
               strategy={verticalListSortingStrategy}
             >
-              <div className="current-activity-doing-list">
+              <div className="current-activity-doing-list" ref={listRef}>
+                {/* SVG接続曲線 */}
+                <svg className="doing-list-lines">
+                  {curves.map((curve, i) => (
+                    <path
+                      key={i}
+                      d={curve.path}
+                      stroke={curve.color}
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      fill="none"
+                    />
+                  ))}
+                </svg>
                 {doingTodos.map((todo) => (
                   <SortableDoingItem
                     key={getTodoUniqueId(todo)}

--- a/src/components/SortableDoingItem.tsx
+++ b/src/components/SortableDoingItem.tsx
@@ -3,6 +3,12 @@ import { CSS } from '@dnd-kit/utilities'
 import { GripVertical, ExternalLink } from 'lucide-react'
 import { TodoItem, getTodoUniqueId } from '@/types'
 
+// 親エントリIDから色相を生成（0-360）
+function getHueFromEntryId(entryId: number): number {
+  // ゴールデンアングル（137.5度）を使って色を分散させる
+  return (entryId * 137.5) % 360
+}
+
 interface SortableDoingItemProps {
   todo: TodoItem
   onStatusChange?: (todo: TodoItem, newStatus: 'x') => Promise<void>
@@ -17,6 +23,8 @@ export function SortableDoingItem({
   onScrollToReply,
 }: SortableDoingItemProps) {
   const uniqueId = getTodoUniqueId(todo)
+  const isReplyTask = !!todo.replyId
+  const hasChildren = (todo.childCount ?? 0) > 0
 
   const {
     attributes,
@@ -27,17 +35,29 @@ export function SortableDoingItem({
     isDragging,
   } = useSortable({ id: uniqueId })
 
+  // 親エントリIDから色を生成（濃い色）
+  const hue = getHueFromEntryId(todo.entryId)
+  const parentColor = `hsl(${hue}, 75%, 40%)`
+  const parentColorLight = `hsla(${hue}, 75%, 40%, 0.2)`
+
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-  }
+    '--parent-color': parentColor,
+    '--parent-color-light': parentColorLight,
+  } as React.CSSProperties
+
+  const itemClasses = [
+    'doing-list-item',
+    isDragging && 'is-dragging',
+    isReplyTask && 'is-child',
+    hasChildren && 'has-children',
+    todo.isLastChild && 'is-last-child',
+  ].filter(Boolean).join(' ')
 
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className={`doing-list-item ${isDragging ? 'is-dragging' : ''}`}
-    >
+    <div ref={setNodeRef} style={style} className={itemClasses} data-entry-id={todo.entryId}>
+
       <button
         className="doing-list-item-drag-handle"
         {...attributes}
@@ -53,7 +73,14 @@ export function SortableDoingItem({
           title="完了にする"
         />
       )}
+
       <span className="doing-list-item-text">{todo.text}</span>
+
+      {/* 子タスクバッジ（親の場合） */}
+      {hasChildren && (
+        <span className="doing-list-item-badge">+{todo.childCount}</span>
+      )}
+
       {todo.replyId && onScrollToReply ? (
         <button
           className="doing-list-item-jump"

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,11 +34,15 @@ export interface Reply {
 }
 
 export interface TodoItem {
-  entryId: number      // 元のエントリーID（返信の場合は親エントリーID）
-  replyId?: number     // 返信のID（返信の場合のみ）
-  lineIndex: number    // エントリー/返信内の行番号（1始まり）
-  text: string         // タスクのテキスト部分
-  status: ' ' | '/'    // 未完了 or Doing
+  entryId: number           // 元のエントリーID（返信の場合は親エントリーID）
+  replyId?: number          // 返信のID（返信の場合のみ）
+  lineIndex: number         // エントリー/返信内の行番号（1始まり）
+  text: string              // タスクのテキスト部分
+  status: ' ' | '/'         // 未完了 or Doing
+  parentEntryText?: string  // 親エントリーのテキスト（返信タスクの場合のみ）
+  parentEntryTags?: Tag[]   // 親エントリーのタグ（返信タスクの場合のみ）
+  childCount?: number       // 子タスクの数（親タスクの場合のみ）
+  isLastChild?: boolean     // 最後の子タスクかどうか
 }
 
 // TodoItemのユニークIDを生成（ドラッグ&ドロップ用）


### PR DESCRIPTION
## Summary
- 返信エントリのタスクを親エントリの子タスクとして「今何してる？」セクションに表示
- 親子タスクを色分け表示（同じ親は同じ色）
- 親タスクに子タスク数のバッジ表示（+N）
- チェックボックスの左側からL字型の線で親子を接続
- 複数の親がいても線が被らないようにレーンをずらす

Closes #90

## Test plan
- [ ] 親エントリにDOINGタスクを作成
- [ ] 親エントリに返信を追加し、返信内にDOINGタスクを作成
- [ ] 「今何してる？」セクションで親子関係が線で繋がっていることを確認
- [ ] 複数の親子関係がある場合、線が被らないことを確認
- [ ] ドラッグ&ドロップで並び替えても線が追従することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)