### PR TITLE
feat: タスクのステータスにキャンセルを追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1574,6 +1574,127 @@ textarea::placeholder {
   opacity: 0.85;
 }
 
+/* キャンセル状態 - [-] のチェックボックス */
+.markdown-preview input[type="checkbox"].checkbox-cancelled {
+  border-color: var(--cancelled-checkbox-color, #ef4444);
+  background: linear-gradient(
+    135deg,
+    var(--cancelled-checkbox-bg, rgba(239, 68, 68, 0.15)) 0%,
+    rgba(255, 255, 255, 0.05) 100%
+  );
+  box-shadow:
+    0 2px 6px rgba(239, 68, 68, 0.15),
+    inset 0 1px 2px rgba(255, 255, 255, 0.2);
+}
+
+.markdown-preview input[type="checkbox"].checkbox-cancelled:hover {
+  box-shadow:
+    0 4px 12px rgba(239, 68, 68, 0.25),
+    0 0 16px var(--cancelled-checkbox-bg, rgba(239, 68, 68, 0.2)),
+    inset 0 1px 2px rgba(255, 255, 255, 0.3);
+}
+
+.markdown-preview input[type="checkbox"].checkbox-cancelled::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 15%;
+  right: 15%;
+  height: 2.5px;
+  background: var(--cancelled-checkbox-color, #ef4444);
+  transform: translateY(-50%);
+  border-radius: 2px;
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.15));
+}
+
+/* キャンセル状態のリストアイテム - 取り消し線 */
+.markdown-preview li.cancelled-item {
+  text-decoration: line-through;
+  text-decoration-color: var(--cancelled-strikethrough, rgba(239, 68, 68, 0.5));
+  text-decoration-thickness: 2px;
+  color: var(--cancelled-text, #888);
+  opacity: 0.7;
+  padding: 0.25em 0.5em;
+  margin: 0.15em 0;
+  border-radius: 8px;
+  background: linear-gradient(
+    135deg,
+    var(--cancelled-checkbox-bg, rgba(239, 68, 68, 0.05)) 0%,
+    transparent 100%
+  );
+}
+
+/* ========================================
+   チェックボックス ステータスメニュー（右クリック）
+   ======================================== */
+
+/* ステータス選択メニュー */
+.checkbox-status-menu {
+  z-index: 1000;
+  min-width: 140px;
+  padding: 4px;
+  background: var(--bg-glass, rgba(255, 255, 255, 0.95));
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--border-glass, rgba(0, 0, 0, 0.1));
+  border-radius: 8px;
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.12),
+    0 2px 4px rgba(0, 0, 0, 0.08);
+}
+
+/* ステータスオプション */
+.checkbox-status-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary, #333);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  text-align: left;
+}
+
+.checkbox-status-option:hover {
+  background: var(--bg-hover, rgba(0, 0, 0, 0.06));
+}
+
+.checkbox-status-option.active {
+  background: var(--bg-active, rgba(59, 130, 246, 0.1));
+  color: var(--color-primary, #3b82f6);
+  font-weight: 500;
+}
+
+/* ステータスオプションのアイコン色 */
+.checkbox-status-option:nth-child(1) svg { color: var(--text-secondary, #888); }
+.checkbox-status-option:nth-child(2) svg { color: var(--doing-checkbox-color, #f59e0b); }
+.checkbox-status-option:nth-child(3) svg { color: var(--completed-checkbox-color, #4CAF50); }
+.checkbox-status-option:nth-child(4) svg { color: var(--cancelled-checkbox-color, #ef4444); }
+
+/* ダークモード対応 */
+@media (prefers-color-scheme: dark) {
+  .checkbox-status-menu {
+    background: var(--bg-glass-dark, rgba(30, 30, 30, 0.95));
+    border-color: var(--border-glass-dark, rgba(255, 255, 255, 0.1));
+  }
+
+  .checkbox-status-option {
+    color: var(--text-primary-dark, #eee);
+  }
+
+  .checkbox-status-option:hover {
+    background: var(--bg-hover-dark, rgba(255, 255, 255, 0.08));
+  }
+
+  .checkbox-status-option.active {
+    background: var(--bg-active-dark, rgba(59, 130, 246, 0.2));
+  }
+}
+
 /* TODO選択ボタン - Liquid Glass Style */
 .todo-selector-trigger {
   display: flex;

--- a/src/components/CurrentActivitySection.tsx
+++ b/src/components/CurrentActivitySection.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState, useEffect, useCallback } from 'react'
 import { Sparkles } from 'lucide-react'
 import { TodoItem, getTodoUniqueId } from '@/types'
+import { CheckboxStatus } from '@/utils/checkboxUtils'
 import {
   DndContext,
   closestCenter,
@@ -27,7 +28,7 @@ interface CurrentActivitySectionProps {
   todoItems?: TodoItem[]
   onScrollToEntry?: (entryId: number) => void
   onScrollToReply?: (replyId: number) => void
-  onStatusChange?: (todo: TodoItem, newStatus: 'x') => Promise<void>
+  onStatusChange?: (todo: TodoItem, newStatus: CheckboxStatus) => Promise<void>
   onReorder?: (activeId: string, overId: string) => Promise<void>
 }
 

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -1,8 +1,9 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { Circle, Slash, CheckCircle, XCircle } from 'lucide-react';
 import {
-  CHECKBOX_PATTERN_DOING,
   CHECKBOX_PATTERN_ALL,
   getNextCheckboxStatus,
   type CheckboxStatus
@@ -14,21 +15,69 @@ interface MarkdownPreviewProps {
   onContentUpdate?: (newContent: string) => void;
 }
 
-// Doing状態のコンテキスト（行番号とDoing状態を保持）
+// チェックボックス状態のコンテキスト
 interface CheckboxInfo {
   line: number;
   isDoing: boolean;
+  isCancelled: boolean;
+  isCompleted: boolean;
+  hasCheckbox: boolean;
 }
 const CheckboxInfoContext = createContext<CheckboxInfo | null>(null);
 
+// ステータスメニューの定義
+const STATUS_OPTIONS: { status: CheckboxStatus; label: string; icon: React.ReactNode }[] = [
+  { status: ' ', label: '未完了', icon: <Circle size={14} /> },
+  { status: '/', label: 'DOING', icon: <Slash size={14} /> },
+  { status: 'x', label: '完了', icon: <CheckCircle size={14} /> },
+  { status: '-', label: 'キャンセル', icon: <XCircle size={14} /> },
+];
+
 const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({ content, className, onContentUpdate }) => {
-  // - [/] を一時的に - [ ] に変換してGFMで解析可能にし、後でスタイルを適用
+  // コンテキストメニューの状態（コンポーネントレベルで管理）
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });
+  const [menuTargetLine, setMenuTargetLine] = useState<number | null>(null);
+  const [menuTargetInfo, setMenuTargetInfo] = useState<CheckboxInfo | null>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // メニュー外クリックで閉じる
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    if (menuOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [menuOpen]);
+
+  // - [/] と - [-] を一時的に - [ ] に変換してGFMで解析可能にし、後でスタイルを適用
   const doingLines = new Set<number>();
+  const cancelledLines = new Set<number>();
+  const completedLines = new Set<number>();
+  const checkboxLines = new Set<number>();
+
   const processedContent = content.split('\n').map((line, index) => {
-    const doingMatch = line.match(CHECKBOX_PATTERN_DOING);
-    if (doingMatch) {
-      doingLines.add(index + 1); // 1始まり
-      return `${doingMatch[1]}[ ]${doingMatch[2]}`;
+    const match = line.match(CHECKBOX_PATTERN_ALL);
+    if (match) {
+      const status = match[2];
+      checkboxLines.add(index + 1);
+      if (status === '/') {
+        doingLines.add(index + 1);
+        return `${match[1]}[ ]${match[3]}`;
+      }
+      if (status === '-') {
+        cancelledLines.add(index + 1);
+        return `${match[1]}[ ]${match[3]}`;
+      }
+      if (status === 'x' || status === 'X') {
+        completedLines.add(index + 1);
+      }
     }
     return line;
   }).join('\n');
@@ -37,7 +86,6 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({ content, className, o
     if (!onContentUpdate) return;
 
     const lines = content.split('\n');
-    // lineIndexは1始まりなので0始まりに変換
     const index = lineIndex - 1;
 
     if (index >= 0 && index < lines.length) {
@@ -58,6 +106,40 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({ content, className, o
         onContentUpdate(newContent);
       }
     }
+  };
+
+  // 直接ステータスを設定する関数
+  const handleStatusSet = (lineIndex: number, newStatus: CheckboxStatus) => {
+    if (!onContentUpdate) return;
+
+    const lines = content.split('\n');
+    const index = lineIndex - 1;
+
+    if (index >= 0 && index < lines.length) {
+      const line = lines[index];
+      const match = line.match(CHECKBOX_PATTERN_ALL);
+
+      if (match) {
+        const prefix = match[1];
+        const suffix = match[3];
+        const newLine = `${prefix}[${newStatus}]${suffix}`;
+
+        lines[index] = newLine;
+        const newContent = lines.join('\n');
+
+        onContentUpdate(newContent);
+      }
+    }
+  };
+
+  // 行の右クリックハンドラ
+  const handleLineContextMenu = (e: React.MouseEvent, info: CheckboxInfo) => {
+    if (!onContentUpdate || !info.hasCheckbox) return;
+    e.preventDefault();
+    setMenuPosition({ x: e.clientX + 8, y: e.clientY + 8 });
+    setMenuTargetLine(info.line);
+    setMenuTargetInfo(info);
+    setMenuOpen(true);
   };
 
   return (
@@ -82,9 +164,26 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({ content, className, o
           li: ({ node, children, ...props }: any) => {
             const line = node?.position?.start?.line;
             const isDoing = doingLines.has(line);
+            const isCancelled = cancelledLines.has(line);
+            const isCompleted = completedLines.has(line);
+            const hasCheckbox = checkboxLines.has(line);
+            const itemClassName = isDoing ? 'doing-item' : isCancelled ? 'cancelled-item' : undefined;
+
+            const info: CheckboxInfo = {
+              line,
+              isDoing,
+              isCancelled,
+              isCompleted,
+              hasCheckbox,
+            };
+
             return (
-              <CheckboxInfoContext.Provider value={{ line, isDoing }}>
-                <li {...props} className={isDoing ? 'doing-item' : undefined}>
+              <CheckboxInfoContext.Provider value={info}>
+                <li
+                  {...props}
+                  className={`${itemClassName || ''} ${hasCheckbox ? 'checkbox-item' : ''}`.trim() || undefined}
+                  onContextMenu={(e: React.MouseEvent) => handleLineContextMenu(e, info)}
+                >
                   {children}
                 </li>
               </CheckboxInfoContext.Provider>
@@ -96,11 +195,14 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({ content, className, o
 
             if (props.type === 'checkbox') {
               const isDoing = info?.isDoing ?? false;
+              const isCancelled = info?.isCancelled ?? false;
+              const checkboxClassName = isDoing ? 'checkbox-doing' : isCancelled ? 'checkbox-cancelled' : undefined;
+
               return (
                 <input
                   {...props}
                   type="checkbox"
-                  className={isDoing ? 'checkbox-doing' : undefined}
+                  className={checkboxClassName}
                   onChange={() => {
                     if (info?.line !== null && info?.line !== undefined) {
                       handleCheckboxChange(info.line);
@@ -117,6 +219,45 @@ const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({ content, className, o
       >
         {processedContent}
       </ReactMarkdown>
+
+      {/* コンテキストメニュー（React Portalでbody直下に表示） */}
+      {menuOpen && menuTargetLine !== null && createPortal(
+        <div
+          ref={menuRef}
+          className="checkbox-status-menu"
+          style={{
+            position: 'fixed',
+            left: menuPosition.x,
+            top: menuPosition.y,
+          }}
+        >
+          {STATUS_OPTIONS.map((option) => (
+            <button
+              key={option.status}
+              className={`checkbox-status-option ${
+                (option.status === ' ' && !menuTargetInfo?.isDoing && !menuTargetInfo?.isCancelled && !menuTargetInfo?.isCompleted) ||
+                (option.status === '/' && menuTargetInfo?.isDoing) ||
+                (option.status === 'x' && menuTargetInfo?.isCompleted) ||
+                (option.status === '-' && menuTargetInfo?.isCancelled)
+                  ? 'active'
+                  : ''
+              }`}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (menuTargetLine !== null) {
+                  handleStatusSet(menuTargetLine, option.status);
+                }
+                setMenuOpen(false);
+              }}
+            >
+              {option.icon}
+              <span>{option.label}</span>
+            </button>
+          ))}
+        </div>,
+        document.body
+      )}
     </div>
   );
 };

--- a/src/components/SortableDoingItem.tsx
+++ b/src/components/SortableDoingItem.tsx
@@ -1,7 +1,10 @@
+import { useState, useRef, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { GripVertical, ExternalLink } from 'lucide-react'
+import { GripVertical, ExternalLink, Circle, Slash, CheckCircle, XCircle } from 'lucide-react'
 import { TodoItem, getTodoUniqueId } from '@/types'
+import { CheckboxStatus } from '@/utils/checkboxUtils'
 
 // 親エントリIDから色相を生成（0-360）
 function getHueFromEntryId(entryId: number): number {
@@ -9,9 +12,17 @@ function getHueFromEntryId(entryId: number): number {
   return (entryId * 137.5) % 360
 }
 
+// ステータスメニューの定義
+const STATUS_OPTIONS: { status: CheckboxStatus; label: string; icon: React.ReactNode }[] = [
+  { status: ' ', label: '未完了', icon: <Circle size={14} /> },
+  { status: '/', label: 'DOING', icon: <Slash size={14} /> },
+  { status: 'x', label: '完了', icon: <CheckCircle size={14} /> },
+  { status: '-', label: 'キャンセル', icon: <XCircle size={14} /> },
+]
+
 interface SortableDoingItemProps {
   todo: TodoItem
-  onStatusChange?: (todo: TodoItem, newStatus: 'x') => Promise<void>
+  onStatusChange?: (todo: TodoItem, newStatus: CheckboxStatus) => Promise<void>
   onScrollToEntry?: (entryId: number) => void
   onScrollToReply?: (replyId: number) => void
 }
@@ -25,6 +36,26 @@ export function SortableDoingItem({
   const uniqueId = getTodoUniqueId(todo)
   const isReplyTask = !!todo.replyId
   const hasChildren = (todo.childCount ?? 0) > 0
+
+  // 右クリックメニューの状態
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 })
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // メニュー外クリックで閉じる
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+    if (menuOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+    }
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [menuOpen])
 
   const {
     attributes,
@@ -55,49 +86,96 @@ export function SortableDoingItem({
     todo.isLastChild && 'is-last-child',
   ].filter(Boolean).join(' ')
 
+  // 右クリックハンドラ
+  const handleContextMenu = (e: React.MouseEvent) => {
+    if (!onStatusChange) return
+    e.preventDefault()
+    setMenuPosition({ x: e.clientX + 8, y: e.clientY + 8 })
+    setMenuOpen(true)
+  }
+
   return (
-    <div ref={setNodeRef} style={style} className={itemClasses} data-entry-id={todo.entryId}>
-
-      <button
-        className="doing-list-item-drag-handle"
-        {...attributes}
-        {...listeners}
+    <>
+      <div
+        ref={setNodeRef}
+        style={style}
+        className={itemClasses}
+        data-entry-id={todo.entryId}
+        onContextMenu={handleContextMenu}
       >
-        <GripVertical size={14} />
-      </button>
-
-      {onStatusChange && (
         <button
-          className="doing-list-item-checkbox"
-          onClick={() => onStatusChange(todo, 'x')}
-          title="完了にする"
-        />
-      )}
-
-      <span className="doing-list-item-text">{todo.text}</span>
-
-      {/* 子タスクバッジ（親の場合） */}
-      {hasChildren && (
-        <span className="doing-list-item-badge">+{todo.childCount}</span>
-      )}
-
-      {todo.replyId && onScrollToReply ? (
-        <button
-          className="doing-list-item-jump"
-          onClick={() => onScrollToReply(todo.replyId!)}
-          title="返信に移動"
+          className="doing-list-item-drag-handle"
+          {...attributes}
+          {...listeners}
         >
-          <ExternalLink size={14} />
+          <GripVertical size={14} />
         </button>
-      ) : onScrollToEntry && (
-        <button
-          className="doing-list-item-jump"
-          onClick={() => onScrollToEntry(todo.entryId)}
-          title="エントリーに移動"
+
+        {onStatusChange && (
+          <button
+            className="doing-list-item-checkbox"
+            onClick={() => onStatusChange(todo, 'x')}
+            title="完了にする"
+          />
+        )}
+
+        <span className="doing-list-item-text">{todo.text}</span>
+
+        {/* 子タスクバッジ（親の場合） */}
+        {hasChildren && (
+          <span className="doing-list-item-badge">+{todo.childCount}</span>
+        )}
+
+        {todo.replyId && onScrollToReply ? (
+          <button
+            className="doing-list-item-jump"
+            onClick={() => onScrollToReply(todo.replyId!)}
+            title="返信に移動"
+          >
+            <ExternalLink size={14} />
+          </button>
+        ) : onScrollToEntry && (
+          <button
+            className="doing-list-item-jump"
+            onClick={() => onScrollToEntry(todo.entryId)}
+            title="エントリーに移動"
+          >
+            <ExternalLink size={14} />
+          </button>
+        )}
+      </div>
+
+      {/* 右クリックメニュー（React Portal） */}
+      {menuOpen && createPortal(
+        <div
+          ref={menuRef}
+          className="checkbox-status-menu"
+          style={{
+            position: 'fixed',
+            left: menuPosition.x,
+            top: menuPosition.y,
+          }}
         >
-          <ExternalLink size={14} />
-        </button>
+          {STATUS_OPTIONS.map((option) => (
+            <button
+              key={option.status}
+              className={`checkbox-status-option ${option.status === '/' ? 'active' : ''}`}
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                if (onStatusChange) {
+                  onStatusChange(todo, option.status)
+                }
+                setMenuOpen(false)
+              }}
+            >
+              {option.icon}
+              <span>{option.label}</span>
+            </button>
+          ))}
+        </div>,
+        document.body
       )}
-    </div>
+    </>
   )
 }

--- a/src/utils/checkboxUtils.ts
+++ b/src/utils/checkboxUtils.ts
@@ -1,21 +1,24 @@
 /**
  * チェックボックスのステータス型
- * ' ' = 未完了, '/' = DOING, 'x' = 完了
+ * ' ' = 未完了, '/' = DOING, 'x' = 完了, '-' = キャンセル
  */
-export type CheckboxStatus = ' ' | '/' | 'x' | 'X'
+export type CheckboxStatus = ' ' | '/' | 'x' | 'X' | '-'
 
 /** チェックボックスのパターン（未完了 + DOING のみ） */
 export const CHECKBOX_PATTERN_INCOMPLETE = /^(\s*[-*+]\s+)\[([ /])\](.*)$/
 
 /** チェックボックスのパターン（全ステータス） */
-export const CHECKBOX_PATTERN_ALL = /^(\s*[-*+]\s+)\[([ /xX])\](.*)$/
+export const CHECKBOX_PATTERN_ALL = /^(\s*[-*+]\s+)\[([ /xX\-])\](.*)$/
 
 /** DOING状態のパターン */
 export const CHECKBOX_PATTERN_DOING = /^(\s*[-*+]\s+)\[\/\](.*)$/
 
+/** キャンセル状態のパターン */
+export const CHECKBOX_PATTERN_CANCELLED = /^(\s*[-*+]\s+)\[\-\](.*)$/
+
 /**
  * チェックボックスの次のステータスを取得
- * ' ' -> '/' -> 'x' -> ' ' のサイクル
+ * ' ' -> '/' -> 'x' -> '-' -> ' ' のサイクル
  */
 export function getNextCheckboxStatus(current: CheckboxStatus): CheckboxStatus {
   switch (current) {
@@ -25,6 +28,8 @@ export function getNextCheckboxStatus(current: CheckboxStatus): CheckboxStatus {
       return 'x'
     case 'x':
     case 'X':
+      return '-'
+    case '-':
     default:
       return ' '
   }


### PR DESCRIPTION
## Summary
- タスクのステータスに「キャンセル」(`[-]`)を追加
- 右クリックでステータス選択メニューを表示（未完了/DOING/完了/キャンセル）
- 「今何してる？」セクションでも右クリックメニュー対応

## 変更内容
- `checkboxUtils.ts`: CheckboxStatusに`-`追加、遷移関数更新
- `MarkdownPreview.tsx`: 右クリックメニュー、キャンセル状態の表示
- `SortableDoingItem.tsx`: 右クリックメニュー追加
- `App.css`: キャンセル用スタイル、メニュースタイル

## ステータス遷移
```
[ ] → [/] → [x] → [-] → [ ]
未完了  DOING  完了  キャンセル  未完了
```

## Test plan
- [ ] タスク行を右クリックしてメニューが表示されること
- [ ] メニューから各ステータスを選択できること
- [ ] キャンセル状態が赤い横線と取り消し線で表示されること
- [ ] 「今何してる？」セクションでも右クリックメニューが動作すること

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)