### PR TITLE
feat: 選択した行をタスクに変換する機能を追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3412,3 +3412,61 @@ textarea::placeholder {
 .summary-empty-small p {
   margin: 0;
 }
+
+/* ========================================
+   テキストエリア コンテキストメニュー
+   (タスク変換用)
+   ======================================== */
+
+.textarea-context-menu {
+  z-index: 1000;
+  min-width: 160px;
+  padding: 4px;
+  background: var(--bg-glass, rgba(255, 255, 255, 0.95));
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--border-glass, rgba(0, 0, 0, 0.1));
+  border-radius: 8px;
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.12),
+    0 2px 4px rgba(0, 0, 0, 0.08);
+}
+
+.textarea-context-menu-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary, #333);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  text-align: left;
+}
+
+.textarea-context-menu-option:hover {
+  background: var(--bg-hover, rgba(0, 0, 0, 0.06));
+}
+
+.textarea-context-menu-option svg {
+  color: var(--doing-checkbox-color, #f59e0b);
+}
+
+/* ダークモード対応 */
+@media (prefers-color-scheme: dark) {
+  .textarea-context-menu {
+    background: var(--bg-glass-dark, rgba(30, 30, 30, 0.95));
+    border-color: var(--border-glass-dark, rgba(255, 255, 255, 0.1));
+  }
+
+  .textarea-context-menu-option {
+    color: var(--text-primary-dark, #eee);
+  }
+
+  .textarea-context-menu-option:hover {
+    background: var(--bg-hover-dark, rgba(255, 255, 255, 0.08));
+  }
+}

--- a/src/components/EntryCard.tsx
+++ b/src/components/EntryCard.tsx
@@ -194,6 +194,7 @@ export function EntryCard({
             onTagRemove={onEditTagRemove}
             frequentTags={frequentTags}
             recentTags={recentTags}
+            enableTaskConversion={true}
           />
         </div>
       ) : (

--- a/src/utils/taskConversionUtils.ts
+++ b/src/utils/taskConversionUtils.ts
@@ -1,0 +1,97 @@
+import { CHECKBOX_PATTERN_ALL } from './checkboxUtils'
+
+/**
+ * 行がすでにタスク形式かどうかを判定
+ */
+export function isTaskLine(line: string): boolean {
+  return CHECKBOX_PATTERN_ALL.test(line)
+}
+
+/**
+ * 単一行をタスク形式に変換
+ * - すでにタスク形式の場合: そのまま返す
+ * - 空行/空白のみの場合: そのまま返す
+ * - 既存のリストマーカー（-, *, +）がある場合: チェックボックスを追加
+ * - それ以外: `- [ ] ` を先頭に追加（インデント保持）
+ */
+export function convertLineToTask(line: string): string {
+  // 空行または空白のみ
+  if (line.trim() === '') {
+    return line
+  }
+
+  // すでにタスク形式
+  if (isTaskLine(line)) {
+    return line
+  }
+
+  // 既存のリストマーカーがある場合（インデント考慮）
+  const listPattern = /^(\s*)([-*+])\s+(.*)$/
+  const listMatch = line.match(listPattern)
+  if (listMatch) {
+    const [, indent, , content] = listMatch
+    return `${indent}- [ ] ${content}`
+  }
+
+  // インデントを保持して変換
+  const indentMatch = line.match(/^(\s*)(.*)$/)
+  if (indentMatch) {
+    const [, indent, content] = indentMatch
+    return `${indent}- [ ] ${content}`
+  }
+
+  return `- [ ] ${line}`
+}
+
+/**
+ * 複数行をタスク形式に変換
+ */
+export function convertLinesToTasks(lines: string[]): string[] {
+  return lines.map(convertLineToTask)
+}
+
+/**
+ * テキストの選択範囲をタスクに変換
+ * @param fullText 全テキスト
+ * @param selectionStart 選択開始位置
+ * @param selectionEnd 選択終了位置
+ * @returns 変換後の全テキストと新しい選択範囲
+ */
+export function convertSelectionToTasks(
+  fullText: string,
+  selectionStart: number,
+  selectionEnd: number
+): { text: string; newSelectionStart: number; newSelectionEnd: number } {
+  // 選択範囲を含む行の範囲を特定
+  const beforeSelection = fullText.substring(0, selectionStart)
+  const lineStartIndex = beforeSelection.lastIndexOf('\n') + 1
+
+  const afterSelection = fullText.substring(selectionEnd)
+  const lineEndOffset = afterSelection.indexOf('\n')
+  const lineEndIndex =
+    lineEndOffset === -1 ? fullText.length : selectionEnd + lineEndOffset
+
+  // 変換対象の行を抽出
+  const targetText = fullText.substring(lineStartIndex, lineEndIndex)
+  const lines = targetText.split('\n')
+
+  // 各行を変換
+  const convertedLines = convertLinesToTasks(lines)
+  const convertedText = convertedLines.join('\n')
+
+  // 新しいテキストを構築
+  const newText =
+    fullText.substring(0, lineStartIndex) +
+    convertedText +
+    fullText.substring(lineEndIndex)
+
+  // 新しい選択範囲を計算（変換後のテキスト全体を選択）
+  const newSelectionStart = lineStartIndex
+  const newSelectionEnd = lineStartIndex + convertedText.length
+
+  return {
+    text: newText,
+    newSelectionStart,
+    newSelectionEnd,
+  }
+}


### PR DESCRIPTION
## Summary
- 表示モードで行を右クリックするとタスク変換メニューを表示
- 段落・リストアイテムのどこをクリックしてもタスクに変換可能
- 編集モードでもテキスト選択して右クリックで変換可能

Closes #89

## Test plan
- [ ] エントリーの任意の行を右クリックして「タスクに変換」メニューが表示されることを確認
- [ ] メニューをクリックして行が `- [ ]` 形式に変換されることを確認
- [ ] すでにタスク形式の行では変換メニューが表示されないことを確認
- [ ] タスク変換後に編集モードに入らないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)