### PR TITLE
fix: Claude Code起動時のPATH問題とプロンプト入力時のカーソル移動問題を修正

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -17,8 +17,9 @@ export function useKeyboardShortcuts({
 }: UseKeyboardShortcutsProps) {
   useEffect(() => {
     const handleGlobalKeyDown = (e: KeyboardEvent) => {
-      // textareaにフォーカスがある場合はスキップ（各CustomInputで処理する）
-      if (document.activeElement?.tagName === 'TEXTAREA') {
+      // textareaまたはinputにフォーカスがある場合はスキップ（各入力要素で処理する）
+      if (document.activeElement?.tagName === 'TEXTAREA' ||
+          document.activeElement?.tagName === 'INPUT') {
         return
       }
 


### PR DESCRIPTION
## Summary
- ClaudeLaunchDialogのプロンプト入力欄でカーソルキー（←→）を押すと日付が移動してしまう問題を修正
- ビルドしたアプリからClaude Codeを起動しようとすると「No such file or directory」エラーが発生する問題を修正

## Changes
### 1. useKeyboardShortcuts.ts
- グローバルキーボードショートカットのフォーカスチェックに`INPUT`要素を追加
- これにより、Input要素にフォーカスがある場合はカーソルキーで日付移動しなくなる

### 2. claude_logs.rs
- `launch_claude_code`と`resume_claude_code`関数を修正
- `/bin/zsh -l -c "claude ..."` を使用してログインシェル経由で実行
- GUIアプリ起動時でもユーザーのPATH設定が継承されるようになった

## Test plan
- [ ] アプリを起動し、ClaudeLaunchDialogを開く
- [ ] プロンプト入力欄でカーソルキーを押し、テキスト内でカーソルが正常に移動することを確認
- [ ] ダイアログを閉じた状態でカーソルキーを押し、日付が正常に移動することを確認
- [ ] ビルドしたアプリからClaude Codeが正常に起動することを確認

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)