### PR TITLE
feat: Claude Codeセッション管理フローの再設計とPTYセッション紐付け機能

### DIFF
--- a/src-tauri/src/claude_logs.rs
+++ b/src-tauri/src/claude_logs.rs
@@ -356,6 +356,40 @@ pub fn launch_claude_code(
     Ok(session_id)
 }
 
+/// Get current working directory
+#[tauri::command]
+pub fn get_current_working_directory() -> Result<String, String> {
+    std::env::current_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .map_err(|e| e.to_string())
+}
+
+/// Get the Claude project directory path for a given cwd
+/// Returns the project path if it exists, otherwise None
+#[tauri::command]
+pub fn get_project_path_for_cwd(cwd: String) -> Result<Option<String>, String> {
+    match get_claude_project_dir(&cwd) {
+        Ok(path) => Ok(Some(path.to_string_lossy().to_string())),
+        Err(_) => Ok(None),
+    }
+}
+
+/// List sessions for the current working directory
+/// This is a convenience function that automatically finds the Claude project directory
+#[tauri::command]
+pub fn list_sessions_for_cwd(cwd: String) -> Result<Vec<SessionSummary>, String> {
+    // Use the existing list_claude_sessions which already handles cwd to project dir conversion
+    list_claude_sessions(cwd)
+}
+
+/// Get the latest session for a given cwd
+/// Returns the most recently updated session in the project
+#[tauri::command]
+pub fn get_latest_session_for_cwd(cwd: String) -> Result<Option<SessionSummary>, String> {
+    let sessions = list_sessions_for_cwd(cwd)?;
+    Ok(sessions.into_iter().next())
+}
+
 /// Resume a Claude Code session in interactive mode in a new terminal window
 #[tauri::command]
 pub fn resume_claude_code(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -209,6 +209,10 @@ fn main() {
             claude_logs::read_claude_session,
             claude_logs::launch_claude_code,
             claude_logs::resume_claude_code,
+            claude_logs::get_current_working_directory,
+            claude_logs::get_project_path_for_cwd,
+            claude_logs::list_sessions_for_cwd,
+            claude_logs::get_latest_session_for_cwd,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/CwdSelectorDialog.tsx
+++ b/src/components/CwdSelectorDialog.tsx
@@ -1,0 +1,129 @@
+import { useState, useEffect } from 'react'
+import Database from '@tauri-apps/plugin-sql'
+import { CwdSelector } from './CwdSelector'
+import { Button } from './ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from './ui/dialog'
+import { Terminal, ExternalLink } from 'lucide-react'
+import { getSettings } from '../lib/settings'
+
+export type LaunchType = 'app' | 'external'
+
+interface CwdSelectorDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onLaunch: (cwd: string, launchType: LaunchType) => void
+  /** 外部ターミナル起動を許可するか */
+  allowExternal?: boolean
+  /** ダイアログタイトル */
+  title?: string
+}
+
+export function CwdSelectorDialog({
+  open,
+  onOpenChange,
+  onLaunch,
+  allowExternal = true,
+  title = '作業ディレクトリを選択',
+}: CwdSelectorDialogProps) {
+  const [cwd, setCwd] = useState('')
+  const [defaultClaudeCwd, setDefaultClaudeCwd] = useState<string | undefined>(undefined)
+  const [isLoading, setIsLoading] = useState(false)
+
+  // デフォルトcwd設定を読み込み
+  useEffect(() => {
+    if (!open) return
+
+    async function loadDefaultCwd() {
+      setIsLoading(true)
+      try {
+        const db = await Database.load('sqlite:funhou.db')
+        const settings = await getSettings(db)
+        if (settings.defaultClaudeCwd) {
+          setDefaultClaudeCwd(settings.defaultClaudeCwd)
+          // デフォルト値を設定
+          if (!cwd) {
+            setCwd(settings.defaultClaudeCwd)
+          }
+        }
+      } catch (error) {
+        console.error('デフォルトcwd設定の読み込みに失敗しました:', error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    loadDefaultCwd()
+  }, [open])
+
+  // ダイアログを閉じる時にリセット
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) {
+      setCwd('')
+    }
+    onOpenChange(newOpen)
+  }
+
+  const handleLaunchApp = () => {
+    if (!cwd.trim()) return
+    onLaunch(cwd.trim(), 'app')
+    handleOpenChange(false)
+  }
+
+  const handleLaunchExternal = () => {
+    if (!cwd.trim()) return
+    onLaunch(cwd.trim(), 'external')
+    handleOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <CwdSelector
+              value={cwd}
+              onChange={setCwd}
+              defaultCwd={defaultClaudeCwd}
+              disabled={isLoading}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="flex gap-2 sm:justify-end">
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+          >
+            キャンセル
+          </Button>
+          {allowExternal && (
+            <Button
+              variant="outline"
+              onClick={handleLaunchExternal}
+              disabled={!cwd.trim() || isLoading}
+            >
+              <ExternalLink size={14} className="mr-1" />
+              外部ターミナル
+            </Button>
+          )}
+          <Button
+            onClick={handleLaunchApp}
+            disabled={!cwd.trim() || isLoading}
+          >
+            <Terminal size={14} className="mr-1" />
+            アプリ内ターミナル
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/contexts/ClaudeTerminalSessionContext.tsx
+++ b/src/contexts/ClaudeTerminalSessionContext.tsx
@@ -73,6 +73,7 @@ interface ClaudeTerminalSessionContextValue {
   terminateSession: (sessionId: string, graceful?: boolean) => Promise<void>
   resizeSession: (sessionId: string, cols: number, rows: number) => void
   updateSessionName: (sessionId: string, name: string) => void
+  updateSessionClaudeId: (sessionId: string, claudeSessionId: string) => void
 
   // 入出力
   writeToSession: (sessionId: string, data: string) => void
@@ -433,6 +434,23 @@ export function ClaudeTerminalSessionProvider({ children }: { children: ReactNod
     })
   }, [])
 
+  // Claude CodeセッションIDの更新（新規起動後に検出したIDを設定）
+  const updateSessionClaudeId = useCallback((sessionId: string, claudeSessionId: string) => {
+    setSessions((prev) => {
+      const session = prev.get(sessionId)
+      if (!session) return prev
+
+      const updatedSession: TerminalSession = {
+        ...session,
+        claudeSessionId,
+      }
+
+      const newMap = new Map(prev)
+      newMap.set(sessionId, updatedSession)
+      return newMap
+    })
+  }, [])
+
   const value: ClaudeTerminalSessionContextValue = {
     sessions,
     activeSessionId,
@@ -442,6 +460,7 @@ export function ClaudeTerminalSessionProvider({ children }: { children: ReactNod
     terminateSession,
     resizeSession,
     updateSessionName,
+    updateSessionClaudeId,
     writeToSession,
     getSessionOutput,
     subscribeToOutput,

--- a/src/lib/claudeLogs.ts
+++ b/src/lib/claudeLogs.ts
@@ -93,3 +93,23 @@ export async function getClaudeSessionsForProject(
 ): Promise<SessionSummary[]> {
   return listClaudeSessions(projectPath)
 }
+
+// 現在の作業ディレクトリを取得
+export async function getCurrentWorkingDirectory(): Promise<string> {
+  return invoke<string>('get_current_working_directory')
+}
+
+// 作業ディレクトリからClaude Codeプロジェクトパスを取得
+export async function getProjectPathForCwd(cwd: string): Promise<string | null> {
+  return invoke<string | null>('get_project_path_for_cwd', { cwd })
+}
+
+// 作業ディレクトリに対応するClaude Codeセッション一覧を取得
+export async function listSessionsForCwd(cwd: string): Promise<SessionSummary[]> {
+  return invoke<SessionSummary[]>('list_sessions_for_cwd', { cwd })
+}
+
+// 作業ディレクトリの最新セッションを取得
+export async function getLatestSessionForCwd(cwd: string): Promise<SessionSummary | null> {
+  return invoke<SessionSummary | null>('get_latest_session_for_cwd', { cwd })
+}

--- a/src/lib/taskClaudeSessions.ts
+++ b/src/lib/taskClaudeSessions.ts
@@ -11,6 +11,7 @@ interface DbTaskClaudeSession {
   project_path: string
   created_at: string
   name: string | null
+  pty_session_id: string | null
 }
 
 function mapDbToTaskClaudeSession(row: DbTaskClaudeSession): TaskClaudeSession {
@@ -24,6 +25,7 @@ function mapDbToTaskClaudeSession(row: DbTaskClaudeSession): TaskClaudeSession {
     projectPath: row.project_path,
     createdAt: row.created_at,
     name: row.name ?? undefined,
+    ptySessionId: row.pty_session_id ?? undefined,
   }
 }
 
@@ -97,6 +99,21 @@ export async function updateTaskClaudeSessionId(
      SET session_id = ?
      WHERE entry_id = ? AND (reply_id = ? OR (reply_id IS NULL AND ? IS NULL)) AND line_index = ? AND session_id = ?`,
     [newSessionId, task.entryId, task.replyId ?? null, task.replyId ?? null, task.lineIndex, oldSessionId]
+  )
+}
+
+// PTYセッションIDを更新（アプリ内ターミナルとの紐付け用）
+export async function updateTaskClaudePtySessionId(
+  db: Database,
+  task: TaskIdentifier,
+  claudeSessionId: string,
+  ptySessionId: string | null
+): Promise<void> {
+  await db.execute(
+    `UPDATE task_claude_sessions
+     SET pty_session_id = ?
+     WHERE entry_id = ? AND (reply_id = ? OR (reply_id IS NULL AND ? IS NULL)) AND line_index = ? AND session_id = ?`,
+    [ptySessionId, task.entryId, task.replyId ?? null, task.replyId ?? null, task.lineIndex, claudeSessionId]
   )
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,15 @@ export interface TimelineItem {
   replyArchived?: boolean
 }
 
+// プロジェクトマスター情報
+export interface Project {
+  id: number
+  cwd: string
+  projectPath: string
+  name?: string
+  createdAt: string
+}
+
 // タスクとClaude Codeセッションの紐付け情報
 export interface TaskClaudeSession {
   id: number
@@ -115,6 +124,9 @@ export interface TaskClaudeSession {
   projectPath: string
   createdAt: string
   name?: string
+  projectId?: number
+  gitBranch?: string
+  ptySessionId?: string  // アプリ内PTYセッションID
 }
 
 // タスク識別子


### PR DESCRIPTION
## Summary

- Claude Codeセッション管理フローを再設計し、タスクからのセッション起動・再開を改善
- PTYセッションとClaude Codeセッションを紐付け、常に同じPTYセッションを復帰できるように
- TaskClaudeSessionsDialogを中心とした統一された起動フローを実装

## 主な変更点

### DBスキーマ
- `projects`テーブルを新規作成（プロジェクトマスター管理）
- `task_claude_sessions`に`pty_session_id`、`git_branch`カラムを追加

### Tauri側
- `get_latest_session_for_cwd`コマンドを追加（指定cwdの最新セッションを取得）

### フロントエンド
- **TaskClaudeSessionsDialog**: セッション一覧と「アプリ内で再開」「外部で再開」ボタンを追加
- **CwdSelectorDialog**: CWD選択専用コンポーネントを新規作成
- **ClaudeTerminalDialog**: PTYセッションの再接続をサポート
- 「既存を紐付け」後に即座にセッション一覧に表示されるよう修正
- セッション選択時にターミナルを自動起動しないよう修正

## Test plan

- [ ] タスクからセッション管理ダイアログを開き、セッション一覧が表示されることを確認
- [ ] 「アプリ内で再開」ボタンでターミナルが起動することを確認
- [ ] 一度起動したPTYセッションを閉じて再度開くと、同じセッションに再接続されることを確認
- [ ] 「既存を紐づけ」でセッションを選択すると、即座に一覧に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)