### PR TITLE
fix: 内蔵ターミナルでShift+Tabが効かない問題を修正

### DIFF
--- a/src/hooks/useClaudeTerminal.ts
+++ b/src/hooks/useClaudeTerminal.ts
@@ -281,7 +281,12 @@ export function useClaudeTerminal(options?: UseClaudeTerminalOptions) {
           data = '\x1b[3~'
           preventDefault = true
         } else if (e.key === 'Tab') {
-          data = '\t'
+          // Shift+Tab は Back Tab (CSI Z) を送信
+          if (e.shiftKey) {
+            data = '\x1b[Z'
+          } else {
+            data = '\t'
+          }
           preventDefault = true
         } else if (e.key === 'Escape') {
           data = '\x1b'


### PR DESCRIPTION
## Summary
- 内蔵ターミナルでShiftキーが効かずplanモードを呼び出せない問題を修正
- Tabキー処理時にShiftキーの状態をチェックし、Shift+Tabの場合はBack Tabエスケープシーケンス（`\x1b[Z`）を送信するように変更

## 変更内容
`src/hooks/useClaudeTerminal.ts` の `handleKeyDown` 関数で、Shift+Tab の組み合わせを正しく処理するようにした。

## Test plan
- [ ] 内蔵ターミナルでShift+Tabを押してplanモードが呼び出せることを確認
- [ ] 通常のTabキーが引き続き正常に動作することを確認

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)