### PR TITLE
fix: 作業ディレクトリ履歴が正しく更新されない問題を修正

### DIFF
--- a/src/components/ClaudeTerminalDialog.tsx
+++ b/src/components/ClaudeTerminalDialog.tsx
@@ -14,6 +14,7 @@ import { Label } from './ui/label'
 import { useClaudeTerminalSession } from '../contexts/ClaudeTerminalSessionContext'
 import { getSettings } from '../lib/settings'
 import { listClaudeProjects, listClaudeSessions, readClaudeSession, type ProjectInfo, type SessionSummary } from '../lib/claudeLogs'
+import { recordCwdUsage } from '../lib/cwdHistory'
 
 interface ClaudeTerminalDialogProps {
   trigger?: React.ReactNode
@@ -250,6 +251,9 @@ export function ClaudeTerminalDialog({
     try {
       const ptySessionId = await createSession(session.cwd, session.session_id, dirName)
       await openInWindow(ptySessionId)
+      // cwd履歴を記録
+      const db = await Database.load('sqlite:funhou.db')
+      await recordCwdUsage(db, session.cwd)
       setOpen(false)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -273,6 +277,9 @@ export function ClaudeTerminalDialog({
       try {
         const sessionId = await createSession(targetCwd, undefined, dirName)
         await openInWindow(sessionId)
+        // cwd履歴を記録
+        const db = await Database.load('sqlite:funhou.db')
+        await recordCwdUsage(db, targetCwd)
         setOpen(false)
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
@@ -325,6 +332,9 @@ export function ClaudeTerminalDialog({
       )
       // 別ウィンドウで開く
       await openInWindow(sessionId)
+      // cwd履歴を記録
+      const db = await Database.load('sqlite:funhou.db')
+      await recordCwdUsage(db, trimmedCwd)
       setOpen(false)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)

--- a/src/lib/cwdHistory.ts
+++ b/src/lib/cwdHistory.ts
@@ -7,29 +7,66 @@ export interface CwdHistoryItem {
 }
 
 /**
- * entriesテーブルからclaude_cwdの履歴を取得
- * 使用回数でソート
+ * cwdの使用を記録する
+ * cwd_historyテーブルにINSERT or UPDATE
+ */
+export async function recordCwdUsage(db: Database, cwd: string): Promise<void> {
+  if (!cwd || cwd.trim() === '') return
+
+  try {
+    await db.execute(
+      `INSERT INTO cwd_history (cwd, usage_count, last_used)
+       VALUES (?, 1, CURRENT_TIMESTAMP)
+       ON CONFLICT(cwd) DO UPDATE SET
+         usage_count = usage_count + 1,
+         last_used = CURRENT_TIMESTAMP`,
+      [cwd.trim()]
+    )
+  } catch (error) {
+    console.error('cwd履歴の記録に失敗しました:', error)
+  }
+}
+
+/**
+ * entriesテーブルとcwd_historyテーブルからclaude_cwdの履歴を取得
+ * 両方のテーブルからマージして使用回数でソート
  */
 export async function getCwdHistory(db: Database): Promise<CwdHistoryItem[]> {
   try {
+    // entriesテーブルとcwd_historyテーブルの両方から取得してマージ
     const result = await db.select<Array<{
-      claude_cwd: string
+      cwd: string
       usage_count: number
       last_used: string
     }>>(
-      `SELECT
-        claude_cwd,
-        COUNT(*) as usage_count,
-        MAX(timestamp) as last_used
-      FROM entries
-      WHERE claude_cwd IS NOT NULL AND claude_cwd != ''
-      GROUP BY claude_cwd
-      ORDER BY usage_count DESC, last_used DESC
-      LIMIT 20`
+      `SELECT cwd, SUM(usage_count) as usage_count, MAX(last_used) as last_used
+       FROM (
+         -- entriesテーブルからの履歴
+         SELECT
+           claude_cwd as cwd,
+           COUNT(*) as usage_count,
+           MAX(timestamp) as last_used
+         FROM entries
+         WHERE claude_cwd IS NOT NULL AND claude_cwd != ''
+         GROUP BY claude_cwd
+
+         UNION ALL
+
+         -- cwd_historyテーブルからの履歴
+         SELECT
+           cwd,
+           usage_count,
+           last_used
+         FROM cwd_history
+         WHERE cwd IS NOT NULL AND cwd != ''
+       )
+       GROUP BY cwd
+       ORDER BY usage_count DESC, last_used DESC
+       LIMIT 20`
     )
 
     return result.map((row) => ({
-      cwd: row.claude_cwd,
+      cwd: row.cwd,
       usageCount: row.usage_count,
       lastUsed: row.last_used,
     }))

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -364,6 +364,20 @@ export async function getDb() {
           WHERE tcs.entry_id = e.id AND tcs.session_id = e.claude_session_id
         )
     `)
+
+    // 作業ディレクトリ履歴テーブルを作成
+    await db.execute(`
+      CREATE TABLE IF NOT EXISTS cwd_history (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        cwd TEXT NOT NULL UNIQUE,
+        usage_count INTEGER DEFAULT 1,
+        last_used DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `)
+
+    await db.execute(`
+      CREATE INDEX IF NOT EXISTS idx_cwd_history_usage ON cwd_history(usage_count DESC, last_used DESC)
+    `)
   }
   return db
 }


### PR DESCRIPTION
## Summary
- `cwd_history`テーブルを新規追加し、セッション開始時に作業ディレクトリの使用履歴を記録するように修正
- `recordCwdUsage`関数を追加し、ClaudeTerminalDialogの各セッション開始箇所で呼び出し
- `getCwdHistory`関数を改良し、`entries`テーブルと`cwd_history`テーブルの両方からマージして履歴を取得

## Test plan
- [ ] 新規セッションを開始して作業ディレクトリが履歴に記録されることを確認
- [ ] 既存の履歴セッションから再開して履歴が更新されることを確認
- [ ] 作業ディレクトリ履歴のドロップダウンに正しい順序で表示されることを確認

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)