### PR TITLE
feat: セッション通知にベル揺れ・バウンス・虹色キラキラエフェクトを追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3587,41 +3587,187 @@ textarea::placeholder {
   transform: scale(0.95);
 }
 
-/* 選択肢待ち状態のFAB - オレンジ色で強調表示 */
+/* 選択肢待ち状態のFAB - 虹色キラキラグロー + バウンス */
 .claude-terminal-fab.asking-question {
   background: linear-gradient(
     135deg,
-    rgba(251, 146, 60, 0.3) 0%,
-    rgba(249, 115, 22, 0.2) 50%,
-    rgba(234, 88, 12, 0.25) 100%
+    rgba(255, 182, 193, 0.3) 0%,
+    rgba(255, 218, 185, 0.25) 25%,
+    rgba(255, 255, 186, 0.25) 50%,
+    rgba(186, 255, 201, 0.25) 75%,
+    rgba(186, 225, 255, 0.3) 100%
   );
-  border-color: rgba(251, 146, 60, 0.5);
+  border-color: rgba(255, 182, 193, 0.6);
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.08),
-    0 0 20px rgba(251, 146, 60, 0.4),
-    inset 0 1px 1px rgba(255, 255, 255, 0.5);
-  animation: asking-pulse 1.5s ease-in-out infinite;
+    0 0 20px rgba(255, 182, 193, 0.5),
+    0 0 40px rgba(186, 225, 255, 0.3),
+    inset 0 1px 1px rgba(255, 255, 255, 0.6);
+  animation:
+    asking-sparkle 2s ease-in-out infinite,
+    asking-bounce 0.6s ease-in-out infinite;
 }
 
 .claude-terminal-fab.asking-question:hover {
   box-shadow:
     0 2px 6px rgba(0, 0, 0, 0.1),
-    0 0 24px rgba(251, 146, 60, 0.5),
-    inset 0 1px 2px rgba(255, 255, 255, 0.6);
+    0 0 30px rgba(255, 182, 193, 0.6),
+    0 0 50px rgba(186, 225, 255, 0.4),
+    inset 0 1px 2px rgba(255, 255, 255, 0.7);
 }
 
-@keyframes asking-pulse {
+/* 虹色キラキラグロー効果 */
+@keyframes asking-sparkle {
   0%, 100% {
     box-shadow:
       0 1px 3px rgba(0, 0, 0, 0.08),
-      0 0 20px rgba(251, 146, 60, 0.4),
-      inset 0 1px 1px rgba(255, 255, 255, 0.5);
+      0 0 20px rgba(255, 182, 193, 0.5),
+      0 0 40px rgba(186, 225, 255, 0.3),
+      inset 0 1px 1px rgba(255, 255, 255, 0.6);
+    border-color: rgba(255, 182, 193, 0.6);
+  }
+  25% {
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.08),
+      0 0 25px rgba(255, 218, 185, 0.6),
+      0 0 45px rgba(255, 182, 193, 0.4),
+      inset 0 1px 1px rgba(255, 255, 255, 0.6);
+    border-color: rgba(255, 218, 185, 0.6);
   }
   50% {
     box-shadow:
       0 1px 3px rgba(0, 0, 0, 0.08),
-      0 0 32px rgba(251, 146, 60, 0.6),
-      inset 0 1px 1px rgba(255, 255, 255, 0.5);
+      0 0 30px rgba(186, 255, 201, 0.6),
+      0 0 50px rgba(255, 255, 186, 0.4),
+      inset 0 1px 1px rgba(255, 255, 255, 0.6);
+    border-color: rgba(186, 255, 201, 0.6);
+  }
+  75% {
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.08),
+      0 0 25px rgba(186, 225, 255, 0.6),
+      0 0 45px rgba(186, 255, 201, 0.4),
+      inset 0 1px 1px rgba(255, 255, 255, 0.6);
+    border-color: rgba(186, 225, 255, 0.6);
+  }
+}
+
+/* バウンスアニメーション */
+@keyframes asking-bounce {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+}
+
+/* ベルアイコンの揺れアニメーション（振り子スタイル） */
+@keyframes bell-swing {
+  0%, 100% {
+    transform: rotate(0deg);
+  }
+  15% {
+    transform: rotate(15deg);
+  }
+  30% {
+    transform: rotate(-12deg);
+  }
+  45% {
+    transform: rotate(9deg);
+  }
+  60% {
+    transform: rotate(-6deg);
+  }
+  75% {
+    transform: rotate(3deg);
+  }
+  90% {
+    transform: rotate(-1deg);
+  }
+}
+
+/* ベルアイコンのスタイル */
+.claude-terminal-fab .bell-icon,
+.bell-icon {
+  display: inline-block;
+  transform-origin: top center;
+}
+
+/* 選択肢待ち状態のベルアイコンアニメーション */
+.claude-terminal-fab.asking-question .bell-icon,
+.bell-icon {
+  animation: bell-swing 1.2s ease-in-out infinite;
+}
+
+/* ドックアイテムの選択肢待ち状態 - 虹色キラキラグロー + バウンス */
+.dock-item-asking {
+  background: linear-gradient(
+    135deg,
+    rgba(255, 182, 193, 0.4) 0%,
+    rgba(255, 218, 185, 0.35) 25%,
+    rgba(255, 255, 186, 0.35) 50%,
+    rgba(186, 255, 201, 0.35) 75%,
+    rgba(186, 225, 255, 0.4) 100%
+  ) !important;
+  box-shadow:
+    0 0 15px rgba(255, 182, 193, 0.5),
+    0 0 30px rgba(186, 225, 255, 0.3),
+    inset 0 1px 1px rgba(255, 255, 255, 0.4);
+  animation:
+    dock-sparkle 2s ease-in-out infinite,
+    dock-bounce 0.6s ease-in-out infinite;
+}
+
+/* ドック用虹色キラキラグロー効果 */
+@keyframes dock-sparkle {
+  0%, 100% {
+    box-shadow:
+      0 0 15px rgba(255, 182, 193, 0.5),
+      0 0 30px rgba(186, 225, 255, 0.3),
+      inset 0 1px 1px rgba(255, 255, 255, 0.4);
+  }
+  25% {
+    box-shadow:
+      0 0 18px rgba(255, 218, 185, 0.6),
+      0 0 35px rgba(255, 182, 193, 0.4),
+      inset 0 1px 1px rgba(255, 255, 255, 0.4);
+  }
+  50% {
+    box-shadow:
+      0 0 20px rgba(186, 255, 201, 0.6),
+      0 0 40px rgba(255, 255, 186, 0.4),
+      inset 0 1px 1px rgba(255, 255, 255, 0.4);
+  }
+  75% {
+    box-shadow:
+      0 0 18px rgba(186, 225, 255, 0.6),
+      0 0 35px rgba(186, 255, 201, 0.4),
+      inset 0 1px 1px rgba(255, 255, 255, 0.4);
+  }
+}
+
+/* ドック用バウンスアニメーション */
+@keyframes dock-bounce {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+/* アクセシビリティ: モーション軽減設定対応 */
+@media (prefers-reduced-motion: reduce) {
+  .claude-terminal-fab.asking-question .bell-icon,
+  .bell-icon {
+    animation: none;
+  }
+  .claude-terminal-fab.asking-question {
+    animation: none;
+  }
+  .dock-item-asking {
+    animation: none;
   }
 }
 

--- a/src/components/ClaudeTerminalDock.tsx
+++ b/src/components/ClaudeTerminalDock.tsx
@@ -86,6 +86,7 @@ export function ClaudeTerminalDock() {
                   ? 'bg-white/20 ring-1 ring-white/30'
                   : 'bg-white/10 hover:bg-white/15'
                 }
+                ${session.status === 'asking_question' ? 'dock-item-asking' : ''}
               `}
               title={`${title} - ${session.status}${windowOpen ? ' (opened)' : ''}`}
             >
@@ -104,6 +105,11 @@ export function ClaudeTerminalDock() {
 
               {/* ステータスアイコン（初期化中のみ） */}
               {getStatusIcon(session.status)}
+
+              {/* ベルアイコン（選択肢待ちの場合） */}
+              {session.status === 'asking_question' && (
+                <span className="bell-icon text-sm">🔔</span>
+              )}
 
               {/* 外部ウィンドウアイコン（開いている場合） */}
               {windowOpen && (

--- a/src/components/ClaudeTerminalWidget.tsx
+++ b/src/components/ClaudeTerminalWidget.tsx
@@ -254,11 +254,9 @@ export function ClaudeTerminalWidget({ isOpen, onToggle }: ClaudeTerminalWidgetP
   }
 
   // FAB表示テキスト
-  const fabText = askingCount > 0
-    ? `🔔 ${askingCount} 選択肢待ち`
-    : runningCount > 0
-      ? `${runningCount} セッション実行中`
-      : `${activeSessions.length} セッション`
+  const fabText = runningCount > 0
+    ? `${runningCount} セッション実行中`
+    : `${activeSessions.length} セッション`
 
   // FABの色
   const fabIndicatorColor = askingCount > 0
@@ -277,7 +275,12 @@ export function ClaudeTerminalWidget({ isOpen, onToggle }: ClaudeTerminalWidgetP
           aria-label={askingCount > 0 ? '選択肢が待機中です' : 'Claude Terminalを開く'}
         >
           <div className={`w-2 h-2 rounded-full ${fabIndicatorColor}`} />
-          <span className="ml-1 text-xs">{fabText}</span>
+          {askingCount > 0 && (
+            <span className="bell-icon">🔔</span>
+          )}
+          <span className="ml-1 text-xs">
+            {askingCount > 0 ? `${askingCount} 選択肢待ち` : fabText}
+          </span>
         </button>
       )}
 


### PR DESCRIPTION
## Summary
- 選択肢待ち状態(asking_question)の視認性を大幅に向上
- FABボタンにベルアイコン🔔の揺れアニメーション（振り子スタイル）を追加
- FABボタンとドックアイテムにバウンス＋虹色キラキラグロー効果を追加
- アクセシビリティ対応（prefers-reduced-motion設定時はアニメーション無効化）

## Test plan
- [ ] セッションを開始して選択肢待ち状態にする
- [ ] FABボタンのベルアイコンが左右に揺れることを確認
- [ ] FABボタン全体がバウンドすることを確認
- [ ] FABボタンが虹色にキラキラ光ることを確認
- [ ] ドックアイテムも同様のエフェクトが適用されることを確認
- [ ] システム設定でモーション軽減をONにした場合、アニメーションが無効化されることを確認

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)