### PR TITLE
fix: ウィンドウドラッグの挙動を改善

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,6 +47,7 @@
             "core:webview:allow-internal-toggle-devtools",
             "core:window:allow-set-always-on-top",
             "core:window:allow-set-position",
+            "core:window:allow-start-dragging",
             "core:window:allow-outer-position",
             "core:window:allow-outer-size",
             "core:window:allow-show",

--- a/src/hooks/useWindowDrag.ts
+++ b/src/hooks/useWindowDrag.ts
@@ -1,57 +1,20 @@
-import { useEffect, useRef, useCallback } from 'react'
-import { getCurrentWindow, PhysicalPosition } from '@tauri-apps/api/window'
-
-// ドラッグ状態をモジュールレベルで管理
-let isDragging = false
-let dragStartX = 0
-let dragStartY = 0
-let windowStartX = 0
-let windowStartY = 0
+import { useCallback } from 'react'
+import { getCurrentWindow } from '@tauri-apps/api/window'
 
 export function useWindowDrag() {
-  const dragRegionRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    const handleMouseMove = async (e: MouseEvent) => {
-      if (!isDragging) return
-      const deltaX = e.screenX - dragStartX
-      const deltaY = e.screenY - dragStartY
-      const newX = windowStartX + deltaX
-      const newY = windowStartY + deltaY
-      try {
-        await getCurrentWindow().setPosition(new PhysicalPosition(newX, newY))
-      } catch (err) {
-        console.error('Failed to set window position:', err)
-      }
-    }
-
-    const handleMouseUp = () => {
-      isDragging = false
-    }
-
-    document.addEventListener('mousemove', handleMouseMove)
-    document.addEventListener('mouseup', handleMouseUp)
-
-    return () => {
-      document.removeEventListener('mousemove', handleMouseMove)
-      document.removeEventListener('mouseup', handleMouseUp)
-    }
-  }, [])
-
   const handleMouseDown = useCallback(async (e: React.MouseEvent) => {
+    // 左クリックのみ処理
+    if (e.button !== 0) return
+
     e.preventDefault()
-    isDragging = true
-    dragStartX = e.screenX
-    dragStartY = e.screenY
+
     try {
-      const position = await getCurrentWindow().outerPosition()
-      windowStartX = position.x
-      windowStartY = position.y
+      // Tauriネイティブのドラッグ開始
+      await getCurrentWindow().startDragging()
     } catch (err) {
-      console.error('Failed to get window position:', err)
-      isDragging = false
+      console.error('Failed to start window dragging:', err)
     }
   }, [])
 
-  return { dragRegionRef, handleMouseDown }
+  return { handleMouseDown }
 }


### PR DESCRIPTION
## Summary

- ウィンドウドラッグ時の「ガタガタする」問題を修正
- TauriのネイティブAPI `startDragging()` を使用することで、OSレベルでスムーズなドラッグを実現
- コードを57行から20行に大幅簡素化

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `src-tauri/tauri.conf.json` | `core:window:allow-start-dragging` パーミッションを追加 |
| `src/hooks/useWindowDrag.ts` | `startDragging()` APIを使用するようにシンプル化 |

## 問題の原因

従来の実装では `mousemove` イベント毎に `await setPosition()` を呼び出しており、非同期処理の遅延とレースコンディションにより「ガタガタ」した動きになっていた。

## Test plan

- [ ] ウィンドウをドラッグして移動できること
- [ ] ドラッグ中にガタガタしないこと（スムーズに動くこと）
- [ ] 左クリック以外（右クリック等）ではドラッグが開始されないこと

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)