### PR TITLE
feat: タスク一覧に親エントリーのタグを表示

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2199,6 +2199,15 @@ textarea::placeholder {
   opacity: 0.7;
 }
 
+/* タグ表示 */
+.doing-list-item-tags {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
+  margin-left: 0.25rem;
+}
+
 /* 子タスクバッジ */
 .doing-list-item-badge {
   font-size: 0.65rem;
@@ -4266,6 +4275,15 @@ textarea::placeholder {
   background: rgba(107, 114, 128, 0.1);
   border-radius: 4px;
   flex-shrink: 0;
+}
+
+/* タグ表示 */
+.incomplete-item-tags {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
+  margin-left: 0.25rem;
 }
 
 /* 子タスクバッジ */

--- a/src/components/SortableDoingItem.tsx
+++ b/src/components/SortableDoingItem.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { GripVertical, ExternalLink, Circle, Slash, CheckCircle, XCircle, Terminal } from 'lucide-react'
+import { TagBadge } from '@/components/TagBadge'
 import { TodoItem, getTodoUniqueId, TaskClaudeSession, TaskIdentifier } from '@/types'
 import { CheckboxStatus } from '@/utils/checkboxUtils'
 import { formatDateToLocalYYYYMMDD } from '@/utils/dateUtils'
@@ -159,6 +160,15 @@ export function SortableDoingItem({
         )}
 
         <span className="doing-list-item-text">{todo.text}</span>
+
+        {/* 親エントリーのタグを表示 */}
+        {todo.parentEntryTags && todo.parentEntryTags.length > 0 && (
+          <div className="doing-list-item-tags">
+            {todo.parentEntryTags.map(tag => (
+              <TagBadge key={tag.id} tag={tag.name} />
+            ))}
+          </div>
+        )}
 
         {/* 日付ラベル */}
         <span className="doing-list-item-date">{formatShortDateLabel(todo.timestamp)}</span>

--- a/src/components/SortableIncompleteItem.tsx
+++ b/src/components/SortableIncompleteItem.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { GripVertical, ExternalLink, Circle, Slash, Terminal } from 'lucide-react'
+import { TagBadge } from '@/components/TagBadge'
 import { IncompleteTodoItem, getIncompleteTodoUniqueId, TaskClaudeSession, TaskIdentifier } from '@/types'
 import { formatDateToLocalYYYYMMDD } from '@/utils/dateUtils'
 
@@ -152,6 +153,15 @@ export function SortableIncompleteItem({
         </button>
 
         <span className="task-item-text">{todo.text}</span>
+
+        {/* 親エントリーのタグを表示 */}
+        {todo.parentEntryTags && todo.parentEntryTags.length > 0 && (
+          <div className="incomplete-item-tags">
+            {todo.parentEntryTags.map(tag => (
+              <TagBadge key={tag.id} tag={tag.name} />
+            ))}
+          </div>
+        )}
 
         {/* 日付ラベル */}
         <span className="incomplete-item-date">{formatShortDateLabel(todo.timestamp)}</span>

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export interface IncompleteTodoItem {
   text: string           // タスクのテキスト部分
   timestamp: string      // エントリー/返信のタイムスタンプ（日付別グルーピング用）
   childCount?: number    // 子タスクの数（親タスクの場合のみ）
+  parentEntryTags?: Tag[] // 親エントリーのタグ
 }
 
 // IncompleteTodoItemのユニークIDを生成（ドラッグ&ドロップ用）


### PR DESCRIPTION
## Summary
- DOINGタスクと未完了タスクの両方に親エントリーのタグを表示
- 既存の`TagBadge`コンポーネントを再利用
- タスクテキストと日付ラベルの間にタグを表示

## 変更ファイル
- `src/types.ts` - `IncompleteTodoItem`に`parentEntryTags`フィールド追加
- `src/hooks/useTodos.ts` - DOINGタスクにタグ取得ロジック追加
- `src/hooks/useIncompleteTodos.ts` - 未完了タスクにタグ取得ロジック追加
- `src/components/SortableDoingItem.tsx` - タグ表示UI追加
- `src/components/SortableIncompleteItem.tsx` - タグ表示UI追加
- `src/App.css` - タグ表示用スタイル追加

## Test plan
- [ ] DOINGタスクにタグが表示されることを確認
- [ ] 未完了タスクにタグが表示されることを確認
- [ ] タグのないタスクでは何も表示されないことを確認

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)