### PR TITLE
fix: 長いタスクテキストを折り返して全文表示 (#133)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4376,9 +4376,8 @@ textarea::placeholder {
   color: var(--foreground);
   flex: 1;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  word-break: break-word;
+  line-height: 1.4;
 }
 
 .completed-item .task-item-text {


### PR DESCRIPTION
## Summary
- 長いタスクテキストが省略記号（...）で切り詰められる問題を修正
- `.task-item-text` のCSSスタイルを変更し、テキストを折り返して全文表示するように変更
- 未完了タスクと完了タスクの両方に適用

## Changes
- `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap` を削除
- `word-break: break-word`, `line-height: 1.4` を追加

Closes #133

## Test plan
- [ ] 長いタスクテキストが折り返されて全文表示されることを確認
- [ ] 短いタスクテキストの表示に影響がないことを確認
- [ ] 複数行になった場合のレイアウト崩れがないことを確認
- [ ] 完了タスクの打ち消し線が複数行でも正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)