### PR TITLE
feat: 未完了タスクからキャンセルに変更できるようにする

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -188,7 +188,7 @@ function App() {
     incompleteTodos,
     isLoading: isIncompleteLoading,
     loadIncompleteTodos,
-    updateToDoingStatus,
+    updateIncompleteStatus,
     saveIncompleteOrder,
     reorderIncompleteTodos,
   } = useIncompleteTodos({ database })
@@ -761,8 +761,8 @@ function App() {
             isCompletedLoading={isCompletedLoading}
             incompleteTodos={incompleteTodos}
             isIncompleteLoading={isIncompleteLoading}
-            onIncompleteStatusChange={async (todo) => {
-              const success = await updateToDoingStatus(todo)
+            onIncompleteStatusChange={async (todo, newStatus) => {
+              const success = await updateIncompleteStatus(todo, newStatus)
               if (success) {
                 // ステータス変更をエントリとして記録
                 if (database) {
@@ -773,7 +773,7 @@ function App() {
                     db: database,
                     taskText: todo.text,
                     oldStatus: ' ', // 未完了から
-                    newStatus: '/', // DOINGへ
+                    newStatus: newStatus, // 指定されたステータスへ
                     tagNames,
                   })
 

--- a/src/components/TaskManagementPage.tsx
+++ b/src/components/TaskManagementPage.tsx
@@ -40,7 +40,7 @@ interface TaskManagementPageProps {
   // Incomplete tasks
   incompleteTodos: IncompleteTodoItem[]
   isIncompleteLoading: boolean
-  onIncompleteStatusChange: (todo: IncompleteTodoItem) => Promise<void>
+  onIncompleteStatusChange: (todo: IncompleteTodoItem, newStatus: CheckboxStatus) => Promise<void>
   onIncompleteReorder: (activeId: string, overId: string) => Promise<void>
   // Claude Code sessions
   taskSessionsMap?: Map<string, TaskClaudeSession[]>

--- a/src/hooks/useIncompleteTodos.ts
+++ b/src/hooks/useIncompleteTodos.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react'
 import Database from '@tauri-apps/plugin-sql'
 import { IncompleteTodoItem, Entry, Reply, getIncompleteTodoUniqueId, Tag } from '@/types'
-import { CHECKBOX_PATTERN_ALL } from '@/utils/checkboxUtils'
+import { CHECKBOX_PATTERN_ALL, CheckboxStatus } from '@/utils/checkboxUtils'
 import { arrayMove } from '@dnd-kit/sortable'
 
 interface IncompleteOrderRow {
@@ -164,9 +164,10 @@ export function useIncompleteTodos({ database }: UseIncompleteTodosProps) {
     }
   }, [database])
 
-  // 未完了タスクをDOING状態に変更
-  const updateToDoingStatus = useCallback(async (
-    todo: IncompleteTodoItem
+  // 未完了タスクのステータスを変更
+  const updateIncompleteStatus = useCallback(async (
+    todo: IncompleteTodoItem,
+    newStatus: CheckboxStatus
   ): Promise<boolean> => {
     if (!database) return false
 
@@ -185,7 +186,7 @@ export function useIncompleteTodos({ database }: UseIncompleteTodosProps) {
           if (index >= 0 && index < lines.length) {
             const match = lines[index].match(CHECKBOX_PATTERN_ALL)
             if (match) {
-              lines[index] = `${match[1]}[/]${match[3]}`
+              lines[index] = `${match[1]}[${newStatus}]${match[3]}`
               const newContent = lines.join('\n')
 
               await database.execute(
@@ -210,7 +211,7 @@ export function useIncompleteTodos({ database }: UseIncompleteTodosProps) {
           if (index >= 0 && index < lines.length) {
             const match = lines[index].match(CHECKBOX_PATTERN_ALL)
             if (match) {
-              lines[index] = `${match[1]}[/]${match[3]}`
+              lines[index] = `${match[1]}[${newStatus}]${match[3]}`
               const newContent = lines.join('\n')
 
               await database.execute(
@@ -266,7 +267,7 @@ export function useIncompleteTodos({ database }: UseIncompleteTodosProps) {
     incompleteTodos,
     isLoading,
     loadIncompleteTodos,
-    updateToDoingStatus,
+    updateIncompleteStatus,
     saveIncompleteOrder,
     reorderIncompleteTodos
   }


### PR DESCRIPTION
## Summary

- 未完了タスクの右クリックメニューに4つのステータスオプション（未完了、DOING、完了、キャンセル）を追加
- `SortableDoingItem`と同様の操作性を`SortableIncompleteItem`にも実装
- チェックボックスの通常クリックは従来通りDOINGへの変更を維持

Closes #136

## Test plan

- [ ] 未完了タスクを右クリックして4つのステータス（未完了、DOING、完了、キャンセル）が表示されることを確認
- [ ] 「キャンセル」を選択して`[-]`に変更され、未完了リストから消えることを確認
- [ ] 「完了」を選択して`[x]`に変更され、完了リストに移動することを確認
- [ ] 「DOING」を選択して`[/]`に変更され、DOINGリストに移動することを確認
- [ ] チェックボックスの通常クリックでDOINGに変更されること（従来動作）を確認
- [ ] ステータス変更ログが正しく記録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)