### PR TITLE
feat: タスク行を含むエントリーに自動タグ付与機能を追加

### DIFF
--- a/src/components/SettingsSidebar.tsx
+++ b/src/components/SettingsSidebar.tsx
@@ -23,6 +23,7 @@ import {
   setOllamaEnabled,
   setOllamaModel,
   setDefaultClaudeCwd,
+  setTaskAutoTagName,
 } from '@/lib/settings'
 import { open } from '@tauri-apps/plugin-dialog'
 import { Input } from '@/components/ui/input'
@@ -64,6 +65,7 @@ export function SettingsSidebar({
   const [ollamaModels, setOllamaModels] = useState<string[]>([])
   const [isCheckingOllama, setIsCheckingOllama] = useState(false)
   const [defaultClaudeCwd, setDefaultClaudeCwdState] = useState<string>('')
+  const [taskAutoTagName, setTaskAutoTagNameState] = useState<string>('TASK')
 
   useEffect(() => {
     if (isOpen && db) {
@@ -85,6 +87,7 @@ export function SettingsSidebar({
     setOllamaEnabledState(settings.ollamaEnabled ?? false)
     setOllamaModelState(settings.ollamaModel || 'gemma3:4b')
     setDefaultClaudeCwdState(settings.defaultClaudeCwd || '')
+    setTaskAutoTagNameState(settings.taskAutoTagName ?? 'TASK')
   }
 
   const checkOllamaStatus = async () => {
@@ -247,6 +250,16 @@ export function SettingsSidebar({
     }
   }
 
+  const handleTaskAutoTagNameChange = async (value: string) => {
+    if (!db) return
+    try {
+      setTaskAutoTagNameState(value)
+      await setTaskAutoTagName(db, value)
+    } catch (error) {
+      console.error('タスク自動タグ設定の変更に失敗しました:', error)
+    }
+  }
+
   return (
     <>
       {/* トグルボタン（常に表示） */}
@@ -333,6 +346,27 @@ export function SettingsSidebar({
               </SelectContent>
             </Select>
           </div>
+
+          {/* タスク自動タグ 区切り線 */}
+          <div className="settings-section-divider" />
+
+          {/* タスク自動タグ名 */}
+          <div className="settings-item-vertical">
+            <Label htmlFor="task-auto-tag-name">タスク自動タグ</Label>
+            <Input
+              id="task-auto-tag-name"
+              value={taskAutoTagName}
+              onChange={(e) => handleTaskAutoTagNameChange(e.target.value)}
+              placeholder="TASK"
+              className="w-full"
+            />
+            <span className="text-xs text-muted-foreground mt-1">
+              タスク行を含むエントリーに自動付与するタグ名。空欄で無効化。
+            </span>
+          </div>
+
+          {/* フォント 区切り線 */}
+          <div className="settings-section-divider" />
 
           {/* フォント */}
           <div className="settings-item-vertical">

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -14,6 +14,7 @@ export interface Settings {
   ollamaEnabled?: boolean
   ollamaModel?: string
   defaultClaudeCwd?: string
+  taskAutoTagName?: string
 }
 
 export async function getSettings(db: Database): Promise<Settings> {
@@ -33,6 +34,7 @@ export async function getSettings(db: Database): Promise<Settings> {
       ollamaEnabled: false,
       ollamaModel: 'gemma3:4b',
       defaultClaudeCwd: undefined,
+      taskAutoTagName: 'TASK',
     }
 
     result.forEach((row) => {
@@ -56,6 +58,8 @@ export async function getSettings(db: Database): Promise<Settings> {
         settings.ollamaModel = row.value
       } else if (row.key === 'default_claude_cwd') {
         settings.defaultClaudeCwd = row.value
+      } else if (row.key === 'task_auto_tag_name') {
+        settings.taskAutoTagName = row.value
       }
     })
 
@@ -73,6 +77,7 @@ export async function getSettings(db: Database): Promise<Settings> {
       ollamaEnabled: false,
       ollamaModel: 'gemma3:4b',
       defaultClaudeCwd: undefined,
+      taskAutoTagName: 'TASK',
     }
   }
 }
@@ -179,4 +184,11 @@ export async function setDefaultClaudeCwd(
   value: string
 ): Promise<void> {
   await saveSetting(db, 'default_claude_cwd', value)
+}
+
+export async function setTaskAutoTagName(
+  db: Database,
+  value: string
+): Promise<void> {
+  await saveSetting(db, 'task_auto_tag_name', value)
 }

--- a/src/utils/checkboxUtils.ts
+++ b/src/utils/checkboxUtils.ts
@@ -98,3 +98,11 @@ export function parseClosedTimestamp(line: string): Date | null {
 export function isClosedLine(line: string): boolean {
   return CLOSED_TIMESTAMP_PATTERN.test(line)
 }
+
+/**
+ * コンテンツにタスク行（チェックボックス）が含まれているかを判定
+ */
+export function hasTaskLine(content: string): boolean {
+  const lines = content.split('\n')
+  return lines.some(line => CHECKBOX_PATTERN_ALL.test(line))
+}


### PR DESCRIPTION
## Summary
- タスク行（チェックボックス `- [ ]` など）を含むエントリー/返信作成時に、設定で指定したタグを自動付与する機能を追加
- 設定画面で自動付与するタグ名をカスタマイズ可能（デフォルト: TASK）
- 空欄にすると自動タグ付与を無効化

## 変更ファイル
- `src/lib/settings.ts` - 設定の型・読み書き関数追加
- `src/utils/checkboxUtils.ts` - タスク行検出関数 `hasTaskLine()` 追加
- `src/hooks/useEntries.ts` - エントリー作成・編集時の自動タグ付与
- `src/hooks/useReplies.ts` - 返信作成・編集時の自動タグ付与
- `src/components/SettingsSidebar.tsx` - 設定UIの追加

## Test plan
- [x] タスク行 (`- [ ] タスク`) を含むエントリーを作成し、TASKタグが自動付与されることを確認
- [x] タスク行を含む返信を作成し、TASKタグが自動付与されることを確認
- [x] 設定画面でタグ名を変更し、変更後のタグが付与されることを確認
- [x] 設定画面でタグ名を空欄にし、自動タグ付与が無効になることを確認
- [x] 既に手動でタグを選択している場合、重複して追加されないことを確認

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)