### PR TITLE
fix: 日次サマリーサイドバーのボタンを左下に配置 (#152)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3175,10 +3175,10 @@ textarea::placeholder {
    Daily Summary Sidebar - 日次サマリーサイドバー
    ======================================== */
 
-/* トグルボタン - 左側に配置 - Liquid Glass Style */
+/* トグルボタン - 左下に配置 - Liquid Glass Style */
 .summary-sidebar-toggle-fab {
   position: fixed;
-  top: 8rem;
+  bottom: 1rem;
   left: 1rem;
   width: 40px;
   height: 40px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
-import { GripVertical } from 'lucide-react'
+import { GripVertical, Sparkles } from 'lucide-react'
 import './App.css'
 import { ClaudeTerminalSessionProvider } from '@/contexts/ClaudeTerminalSessionContext'
 import { ClaudeTerminalWidget } from '@/components/ClaudeTerminalWidget'
@@ -516,6 +516,16 @@ function App() {
   return (
     <ClaudeTerminalSessionProvider>
     <div className="app">
+      {/* 日次サマリーサイドバーのトグルボタン（左下に配置） */}
+      {!summarySidebarOpen && (
+        <button
+          className="summary-sidebar-toggle-fab"
+          onClick={() => setSummarySidebarOpen(!summarySidebarOpen)}
+          aria-label="日次サマリーを開く"
+        >
+          <Sparkles size={14} />
+        </button>
+      )}
       <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as 'funhou' | 'tasks')} className="app-tabs">
         <div className="app-tabs-header">
           <TabsList className="app-tabs-list">

--- a/src/components/DailySummarySidebar.tsx
+++ b/src/components/DailySummarySidebar.tsx
@@ -100,17 +100,6 @@ export function DailySummarySidebar({
 
   return (
     <>
-      {/* トグルボタン（常に表示） */}
-      {!isOpen && (
-        <button
-          className="summary-sidebar-toggle-fab"
-          onClick={onToggle}
-          aria-label="日次サマリーを開く"
-        >
-          <Sparkles size={14} />
-        </button>
-      )}
-
       {/* オーバーレイ */}
       {isOpen && (
         <div


### PR DESCRIPTION
## 変更内容\n\n- 日次サマリーサイドバーのトグルボタンを左下に配置\n- CSSのをに変更\n- ボタンをコンポーネントからに移動し、DOM順序を調整（の最初の子要素として配置）\n\n## 関連Issue\n\nCloses #152