### PR TITLE
fix: タスク並べ替え時のアニメーションで間延びする問題を修正 (#154)

### DIFF
--- a/src/components/SortableDoingItem.tsx
+++ b/src/components/SortableDoingItem.tsx
@@ -112,7 +112,7 @@ export function SortableDoingItem({
   const parentColorLight = `hsla(${hue}, 75%, 40%, 0.2)`
 
   const style = {
-    transform: CSS.Transform.toString(transform),
+    transform: CSS.Translate.toString(transform),
     transition,
     '--parent-color': parentColor,
     '--parent-color-light': parentColorLight,

--- a/src/components/SortableIncompleteItem.tsx
+++ b/src/components/SortableIncompleteItem.tsx
@@ -109,7 +109,7 @@ export function SortableIncompleteItem({
   const parentColorLight = `hsla(${hue}, 75%, 40%, 0.2)`
 
   const style = {
-    transform: CSS.Transform.toString(transform),
+    transform: CSS.Translate.toString(transform),
     transition,
     '--parent-color': parentColor,
     '--parent-color-light': parentColorLight,


### PR DESCRIPTION
## Summary
- タスクをドラッグ＆ドロップで並べ替える際に、移動中のアイテムが間延びして表示される問題を修正
- `CSS.Transform.toString()` を `CSS.Translate.toString()` に変更し、scale変換を除外

## Changes
- `SortableDoingItem.tsx`: CSS.Transform → CSS.Translate
- `SortableIncompleteItem.tsx`: CSS.Transform → CSS.Translate

## Test plan
- [x] DOINGリストでタスクをドラッグ＆ドロップし、アイテムが間延びせずにアニメーションすることを確認
- [x] 未完了タスクリストでも同様に確認

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)