### PR TITLE
fix: ステータス変更を記録するエントリを最初からアーカイブ状態にする

### DIFF
--- a/src/utils/statusChangeLogger.ts
+++ b/src/utils/statusChangeLogger.ts
@@ -48,9 +48,9 @@ export async function logStatusChange({
     // 記録エントリのコンテンツ
     const content = `${taskText} を ${oldLabel} から ${newLabel} に変更`
 
-    // エントリを作成
+    // エントリを作成（ステータス変更記録は最初からアーカイブ状態にする）
     const result = await db.execute(
-      'INSERT INTO entries (content, timestamp) VALUES (?, ?)',
+      'INSERT INTO entries (content, timestamp, archived) VALUES (?, ?, 1)',
       [content, timestamp]
     )
 


### PR DESCRIPTION
## Summary
- ステータス変更時に自動作成される記録エントリを、最初からアーカイブ状態で保存するように変更
- タイムラインに「タスク名 を 未完了 から DOING に変更」などの記録が表示されなくなる

## Changes
- `src/utils/statusChangeLogger.ts`: INSERT文に `archived = 1` を追加

## Test plan
- [x] タスクのステータスを変更する（例：未完了 → DOING）
- [x] 作成された記録エントリがタイムラインに表示されないことを確認
- [x] アーカイブ表示モードで記録エントリが確認できることを確認

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)