### PR TITLE
fix: 内部ターミナルを復帰させた時の描画が真っ黒になる問題を修正

### DIFF
--- a/src/components/ClaudeTerminalWindow.tsx
+++ b/src/components/ClaudeTerminalWindow.tsx
@@ -71,6 +71,9 @@ export function ClaudeTerminalWindow({ sessionId }: ClaudeTerminalWindowProps) {
     setTerminal(term)
     setIsReady(true)
 
+    // メインウィンドウに初期化完了を通知
+    sendToMainWindow(sessionId, { type: 'ready', data: null })
+
     return () => {
       term.dispose()
     }
@@ -94,6 +97,11 @@ export function ClaudeTerminalWindow({ sessionId }: ClaudeTerminalWindowProps) {
           const data = payload.data as string
           terminal.write(data)
           outputBufferRef.current.push(data)
+        } else if (payload.type === 'buffer') {
+          // 過去のバッファを復元（ウィンドウ再オープン時）
+          const bufferData = payload.data as string[]
+          bufferData.forEach((chunk) => terminal.write(chunk))
+          outputBufferRef.current.push(...bufferData)
         } else if (payload.type === 'status') {
           // ステータス変更の処理（必要に応じて）
         } else if (payload.type === 'terminate') {

--- a/src/lib/windowBridge.ts
+++ b/src/lib/windowBridge.ts
@@ -6,7 +6,7 @@ import { invoke } from '@tauri-apps/api/core'
  */
 export interface SessionSyncPayload {
   sessionId: string
-  type: 'output' | 'input' | 'status' | 'resize' | 'terminate'
+  type: 'output' | 'input' | 'status' | 'resize' | 'terminate' | 'ready' | 'buffer'
   data: unknown
 }
 


### PR DESCRIPTION
## Summary
- 別ウィンドウのターミナルを閉じて再度開くと画面が真っ黒になる問題を修正
- `ready`シグナルによるハンドシェイクで初期化完了を確実に検知
- 過去のバッファを`buffer`イベントで一括送信して復元

## 変更内容
| ファイル | 修正内容 |
|---------|---------|
| `src/lib/windowBridge.ts` | `SessionSyncPayload`に`'ready'`と`'buffer'`タイプを追加 |
| `src/components/ClaudeTerminalWindow.tsx` | Terminal初期化完了時に`ready`シグナル送信、`buffer`受信処理を追加 |
| `src/contexts/ClaudeTerminalSessionContext.tsx` | `ready`シグナル受信時にバッファ送信とforwarder登録 |

## 修正の詳細

### Before（問題）
- ウィンドウを再度開いた時、メインウィンドウは別ウィンドウの準備ができたことを知らずにforwarderを登録
- 過去のバッファを送信する処理がなかった
- ターミナル初期化前にイベントが来て出力が表示されなかった

### After（解決）
1. 別ウィンドウがTerminal初期化完了時に `ready` シグナルを送信
2. メインウィンドウが `ready` を受信したら過去のバッファを `buffer` として一括送信
3. その後、forwarderを登録して新しい出力をリアルタイム転送

## Test plan
- [ ] ターミナルを別ウィンドウで開く
- [ ] 何か出力がある状態でウィンドウを閉じる
- [ ] ドックから再度開く -> 過去の出力が表示されることを確認
- [ ] 新しいコマンドを実行 -> 出力がリアルタイムで表示されることを確認
- [ ] 入力が正しく機能することを確認

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)