### PR TITLE
feat: タスクをクリックすると返信プレビューダイアログを表示する機能を追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2219,6 +2219,243 @@ textarea::placeholder {
   flex-shrink: 0;
 }
 
+/* 展開トグルボタン */
+.doing-list-item-expand,
+.incomplete-item-expand {
+  background: none;
+  border: none;
+  padding: 0.125rem;
+  cursor: pointer;
+  color: var(--muted-foreground);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  opacity: 0.6;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.doing-list-item-expand:hover,
+.incomplete-item-expand:hover {
+  opacity: 1;
+  color: var(--foreground);
+}
+
+/* 返信エントリの展開表示 - タイムライン風 */
+.doing-list-item-expanded-replies,
+.incomplete-item-expanded-replies {
+  margin-left: 1.5rem;
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
+  padding-left: 1rem;
+  border-left: 2px solid var(--parent-color, hsl(var(--muted-foreground) / 0.3));
+  position: relative;
+}
+
+.doing-list-item-expanded-replies > .expanded-reply-content,
+.incomplete-item-expanded-replies > .expanded-reply-content {
+  position: relative;
+  padding: 0.625rem 0.875rem;
+  margin-bottom: 0.5rem;
+  background: hsl(var(--background) / 0.6);
+  border-radius: 6px;
+  border: 1px solid hsl(var(--border) / 0.5);
+  transition: all 0.15s ease;
+}
+
+.doing-list-item-expanded-replies > .expanded-reply-content:last-child,
+.incomplete-item-expanded-replies > .expanded-reply-content:last-child {
+  margin-bottom: 0;
+}
+
+.doing-list-item-expanded-replies > .expanded-reply-content:hover,
+.incomplete-item-expanded-replies > .expanded-reply-content:hover {
+  background: hsl(var(--background) / 0.9);
+  border-color: var(--parent-color, hsl(var(--border)));
+}
+
+/* タイムラインのドット */
+.doing-list-item-expanded-replies > .expanded-reply-content::before,
+.incomplete-item-expanded-replies > .expanded-reply-content::before {
+  content: '';
+  position: absolute;
+  left: -1.375rem;
+  top: 0.75rem;
+  width: 6px;
+  height: 6px;
+  background: var(--parent-color, hsl(var(--muted-foreground)));
+  border-radius: 50%;
+}
+
+.expanded-reply-loading,
+.expanded-reply-error,
+.expanded-reply-empty {
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+  padding: 0.5rem 0;
+}
+
+.expanded-reply-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.expanded-reply-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.expanded-reply-timestamp {
+  font-size: 0.65rem;
+  color: var(--muted-foreground);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.expanded-reply-tags {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.expanded-reply-tags .tag-badge {
+  font-size: 0.6rem;
+  padding: 0.125rem 0.375rem;
+}
+
+.expanded-reply-body {
+  font-size: 0.8rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: hsl(var(--foreground) / 0.9);
+}
+
+/* 返信プレビューダイアログ */
+.replies-preview-dialog {
+  max-width: 600px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.replies-preview-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--foreground);
+  padding-right: 2rem;
+  flex-shrink: 0;
+}
+
+.replies-preview-content {
+  flex: 1;
+  overflow-y: auto;
+  margin-top: 0.75rem;
+  min-height: 0;
+  max-height: calc(80vh - 120px);
+}
+
+.replies-preview-loading,
+.replies-preview-empty {
+  font-size: 0.85rem;
+  color: var(--muted-foreground);
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+.replies-preview-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.replies-preview-item {
+  padding: 0.875rem;
+  background: hsl(var(--muted) / 0.5);
+  border-radius: 8px;
+  border: 1px solid hsl(var(--border) / 0.5);
+  transition: all 0.15s ease;
+}
+
+.replies-preview-item:hover {
+  background: hsl(var(--muted) / 0.8);
+  border-color: hsl(var(--border));
+}
+
+.replies-preview-item-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+.replies-preview-timestamp {
+  font-size: 0.7rem;
+  color: var(--muted-foreground);
+  font-weight: 500;
+}
+
+.replies-preview-tags {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.replies-preview-tags .tag-badge {
+  font-size: 0.6rem;
+  padding: 0.125rem 0.375rem;
+}
+
+.replies-preview-jump {
+  margin-left: auto;
+  background: none;
+  border: none;
+  padding: 0.25rem;
+  cursor: pointer;
+  color: var(--muted-foreground);
+  border-radius: 4px;
+  transition: all 0.15s ease;
+}
+
+.replies-preview-jump:hover {
+  color: var(--foreground);
+  background: hsl(var(--muted));
+}
+
+.replies-preview-item-body {
+  font-size: 0.85rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: hsl(var(--foreground) / 0.9);
+}
+
+/* 返信ボタンスタイル */
+.doing-list-item-replies,
+.incomplete-item-replies {
+  background: none;
+  border: none;
+  padding: 0.25rem;
+  cursor: pointer;
+  color: var(--muted-foreground);
+  border-radius: 4px;
+  transition: all 0.15s ease;
+  display: flex;
+  align-items: center;
+}
+
+.doing-list-item-replies:hover,
+.incomplete-item-replies:hover {
+  color: var(--foreground);
+  background: hsl(var(--muted) / 0.5);
+}
+
 /* 空状態 */
 .current-activity-empty {
   text-align: center;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -805,6 +805,7 @@ function App() {
               setActiveTab('funhou')
               setTimeout(() => scrollToReply(replyId), 100)
             }}
+            database={database}
             onStatusChange={handleTaskStatusChange}
             onReorder={async (activeId, overId) => {
               const reorderedDoingTodos = reorderDoingTodos(activeId, overId)

--- a/src/components/RepliesPreviewDialog.tsx
+++ b/src/components/RepliesPreviewDialog.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { TagBadge } from '@/components/TagBadge'
+import { Reply } from '@/types'
+import { formatTimestamp } from '@/utils/dateUtils'
+import { getRepliesByEntryId } from '@/lib/replies'
+import { ExternalLink } from 'lucide-react'
+import Database from '@tauri-apps/plugin-sql'
+
+interface RepliesPreviewDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  entryId: number | null
+  taskText: string
+  database: Database | null
+  onScrollToReply?: (replyId: number) => void
+}
+
+export function RepliesPreviewDialog({
+  isOpen,
+  onClose,
+  entryId,
+  taskText,
+  database,
+  onScrollToReply,
+}: RepliesPreviewDialogProps) {
+  const [replies, setReplies] = useState<Reply[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    if (isOpen && entryId && database) {
+      setIsLoading(true)
+      getRepliesByEntryId(database, entryId)
+        .then(setReplies)
+        .catch((error) => {
+          console.error('返信の取得に失敗しました:', error)
+          setReplies([])
+        })
+        .finally(() => setIsLoading(false))
+    } else {
+      setReplies([])
+    }
+  }, [isOpen, entryId, database])
+
+  const handleScrollToReply = (replyId: number) => {
+    onClose()
+    onScrollToReply?.(replyId)
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="replies-preview-dialog">
+        <DialogHeader>
+          <DialogTitle className="replies-preview-title">
+            {taskText}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="replies-preview-content">
+          {isLoading ? (
+            <div className="replies-preview-loading">読み込み中...</div>
+          ) : replies.length > 0 ? (
+            <div className="replies-preview-list">
+              {replies.map((reply) => (
+                <div key={reply.id} className="replies-preview-item">
+                  <div className="replies-preview-item-header">
+                    <span className="replies-preview-timestamp">
+                      {formatTimestamp(reply.timestamp)}
+                    </span>
+                    {reply.tags && reply.tags.length > 0 && (
+                      <div className="replies-preview-tags">
+                        {reply.tags.map((tag) => (
+                          <TagBadge key={tag.id} tag={tag.name} />
+                        ))}
+                      </div>
+                    )}
+                    {onScrollToReply && (
+                      <button
+                        className="replies-preview-jump"
+                        onClick={() => handleScrollToReply(reply.id)}
+                        title="返信に移動"
+                      >
+                        <ExternalLink size={14} />
+                      </button>
+                    )}
+                  </div>
+                  <div className="replies-preview-item-body">
+                    {reply.content}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="replies-preview-empty">返信がありません</div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/SortableDoingItem.tsx
+++ b/src/components/SortableDoingItem.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { GripVertical, ExternalLink, Circle, Slash, CheckCircle, XCircle, Terminal } from 'lucide-react'
+import { GripVertical, ExternalLink, Circle, Slash, CheckCircle, XCircle, Terminal, MessageSquare } from 'lucide-react'
 import { TagBadge } from '@/components/TagBadge'
 import { TodoItem, getTodoUniqueId, TaskClaudeSession, TaskIdentifier } from '@/types'
 import { CheckboxStatus } from '@/utils/checkboxUtils'
@@ -50,6 +50,7 @@ interface SortableDoingItemProps {
   onStatusChange?: (todo: TodoItem, newStatus: CheckboxStatus) => Promise<void>
   onScrollToEntry?: (entryId: number) => void
   onScrollToReply?: (replyId: number) => void
+  onPreviewReplies?: (entryId: number, taskText: string) => void
   onLaunchClaude?: (task: TaskIdentifier, taskText: string) => void
   onLaunchClaudeExternal?: (task: TaskIdentifier, taskText: string) => void
   onManageSessions?: (task: TaskIdentifier, taskText: string, sessions: TaskClaudeSession[]) => void
@@ -61,6 +62,7 @@ export function SortableDoingItem({
   onStatusChange,
   onScrollToEntry,
   onScrollToReply,
+  onPreviewReplies,
   onLaunchClaude,
   onLaunchClaudeExternal,
   onManageSessions,
@@ -134,6 +136,11 @@ export function SortableDoingItem({
     setMenuOpen(true)
   }
 
+  // 返信プレビューを開く
+  const handleOpenRepliesPreview = () => {
+    onPreviewReplies?.(todo.entryId, todo.text)
+  }
+
   return (
     <>
       <div
@@ -159,7 +166,13 @@ export function SortableDoingItem({
           />
         )}
 
-        <span className="doing-list-item-text">{todo.text}</span>
+        <span
+          className="doing-list-item-text"
+          onClick={handleOpenRepliesPreview}
+          style={{ cursor: onPreviewReplies ? 'pointer' : 'default' }}
+        >
+          {todo.text}
+        </span>
 
         {/* 親エントリーのタグを表示 */}
         {todo.parentEntryTags && todo.parentEntryTags.length > 0 && (
@@ -176,6 +189,17 @@ export function SortableDoingItem({
         {/* 子タスクバッジ（親の場合） */}
         {hasChildren && (
           <span className="doing-list-item-badge">+{todo.childCount}</span>
+        )}
+
+        {/* 返信プレビューボタン */}
+        {onPreviewReplies && (
+          <button
+            className="doing-list-item-replies"
+            onClick={handleOpenRepliesPreview}
+            title="返信を表示"
+          >
+            <MessageSquare size={14} />
+          </button>
         )}
 
         {todo.replyId && onScrollToReply ? (

--- a/src/lib/replies.ts
+++ b/src/lib/replies.ts
@@ -1,0 +1,53 @@
+import Database from '@tauri-apps/plugin-sql'
+import { Reply } from '@/types'
+import { getTagsForReply } from '@/lib/tags'
+
+/**
+ * 返信をIDで取得する
+ * @param db データベース接続
+ * @param replyId 返信ID
+ * @returns 返信データ（タグ付き）、見つからない場合はnull
+ */
+export async function getReplyById(
+  db: Database,
+  replyId: number
+): Promise<Reply | null> {
+  const results = await db.select<Reply[]>(
+    'SELECT id, entry_id, content, timestamp, archived FROM replies WHERE id = ?',
+    [replyId]
+  )
+
+  if (results.length === 0) {
+    return null
+  }
+
+  const reply = results[0]
+
+  // タグを取得
+  reply.tags = await getTagsForReply(db, replyId)
+
+  return reply
+}
+
+/**
+ * エントリIDに紐づく返信一覧を取得する
+ * @param db データベース接続
+ * @param entryId エントリID
+ * @returns 返信データの配列（タグ付き）
+ */
+export async function getRepliesByEntryId(
+  db: Database,
+  entryId: number
+): Promise<Reply[]> {
+  const results = await db.select<Reply[]>(
+    'SELECT id, entry_id, content, timestamp, archived FROM replies WHERE entry_id = ? ORDER BY timestamp ASC',
+    [entryId]
+  )
+
+  // 各返信にタグを取得
+  for (const reply of results) {
+    reply.tags = await getTagsForReply(db, reply.id)
+  }
+
+  return results
+}


### PR DESCRIPTION
## Summary
- タスクのテキストをクリックすると、そのタスクに関連する返信を一覧表示するダイアログを追加
- 返信アイコン（MessageSquare）ボタンを追加し、クリックでプレビューダイアログを表示
- ダイアログ内から返信に直接ジャンプする機能を追加

## Test plan
- [ ] DOINGリストのタスクをクリックして返信プレビューダイアログが開くことを確認
- [ ] 未完了タスクリストのタスクをクリックして返信プレビューダイアログが開くことを確認
- [ ] 返信がある場合、タイムスタンプ・タグ・内容が正しく表示されることを確認
- [ ] 返信がない場合、「返信がありません」と表示されることを確認
- [ ] 返信の「移動」ボタンをクリックして該当返信にスクロールすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)