### PR TITLE
fix: 外部アプリへのメッセージ送信機能を修正

### DIFF
--- a/src/components/InputSection.tsx
+++ b/src/components/InputSection.tsx
@@ -99,7 +99,7 @@ export const InputSection = forwardRef<CustomInputRef, InputSectionProps>(functi
               runningApps.map((app) => (
                 <DropdownMenuItem
                   key={app.name}
-                  onClick={() => selectTargetApp(app.name)}
+                  onClick={() => selectTargetApp(app)}
                   className={targetApp === app.name ? 'bg-accent' : ''}
                 >
                   {app.name}

--- a/src/lib/pasteToApp.ts
+++ b/src/lib/pasteToApp.ts
@@ -30,12 +30,13 @@ export async function getRunningApps(): Promise<AppInfo[]> {
  * 指定したアプリにテキストをペースト
  * @param text 送信するテキスト
  * @param targetApp 送信先アプリ名
+ * @param bundleId 送信先アプリのBundle ID（オプション、あればより確実にアクティブ化できる）
  * @returns 送信結果
  */
-export async function pasteTextToApp(text: string, targetApp: string): Promise<PasteResult> {
-  console.log('[pasteToApp] Invoking paste_text_to_app with text:', text.substring(0, 50), 'target:', targetApp)
+export async function pasteTextToApp(text: string, targetApp: string, bundleId?: string): Promise<PasteResult> {
+  console.log('[pasteToApp] Invoking paste_text_to_app with text:', text.substring(0, 50), 'target:', targetApp, 'bundleId:', bundleId)
   try {
-    const result = await invoke<PasteResult>('paste_text_to_app', { text, targetApp })
+    const result = await invoke<PasteResult>('paste_text_to_app', { text, targetApp, bundleId })
     console.log('[pasteToApp] Result:', result)
     return result
   } catch (error) {


### PR DESCRIPTION
## Summary
- Bundle IDを使用してアプリをアクティブ化するように変更
- アプリ名でactivateできないアプリ（Wave等）に対応
- フロントエンドでBundle IDをlocalStorageに保存して永続化

## 原因
一部のアプリ（Wave等）では `tell application "AppName" to activate` でアクティブ化できないが、`tell application id "bundle.id"` なら動作する。

## 変更内容
- `paste_to_app.rs`: `bundle_id`パラメータを追加し、Bundle IDがあれば`tell application id`を使用
- `pasteToApp.ts`: `bundleId`パラメータを追加
- `usePasteToApp.ts`: Bundle IDをstateとlocalStorageで管理
- `InputSection.tsx`: AppInfo全体を渡すように変更

## Test plan
- [ ] Waveアプリへのメッセージ送信が動作すること
- [ ] 他のアプリ（Slack, LINE等）への送信も引き続き動作すること
- [ ] アプリ選択がlocalStorageに保存されること

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)